### PR TITLE
Configure js apps with backend url before S3 deploy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 .PHONY: *
 
 APP=
@@ -34,6 +36,10 @@ APP_STAGING_HEROKU_shipit_dashboard=shipit-staging-dashboard
 APP_STAGING_S3_releng_docs=releng-staging-docs
 APP_STAGING_S3_releng_frontend=releng-staging-frontend
 APP_STAGING_S3_shipit_frontend=shipit-staging-frontend
+APP_STAGING_ENV_releng_frontend=\
+	BACKEND_URL=https://backend.releng.staging.mozilla-releng.net
+APP_STAGING_ENV_shipit_frontend=\
+	REAL_DASHBOARD_URL=https://dashboard.shipit.staging.mozilla-releng.net
 
 APP_PRODUCTION_HEROKU_releng_clobberer=releng-production-clobberer
 APP_PRODUCTION_HEROKU_shipit_dashboard=shipit-production-dashboard
@@ -41,7 +47,10 @@ APP_PRODUCTION_HEROKU_shipit_dashboard=shipit-production-dashboard
 APP_PRODUCTION_S3_releng_docs=releng-production-docs
 APP_PRODUCTION_S3_releng_frontend=releng-production-frontend
 APP_PRODUCTION_S3_shipit_frontend=shipit-production-frontend
-
+APP_PRODUCTION_ENV_releng_frontend=\
+	BACKEND_URL=https://backend.releng.mozilla-releng.net
+APP_PRODUCTION_ENV_shipit_frontend=\
+	REAL_DASHBOARD_URL=https://dashboard.shipit.mozilla-releng.net
 
 
 help:
@@ -120,14 +129,24 @@ build-app: require-APP build-app-$(APP)
 build-app-%: nix
 	nix-build nix/default.nix -A $(subst build-app-,,$@) -o result-$(subst build-app-,,$@) --fallback
 
+copy-app-%:
+	$(eval APP_TMP := $(shell mktemp -d --tmpdir=$$PWD/tmp $(APP).XXXXX))
+	cp -rf result-$(APP)/* $(APP_TMP)
 
+configure-staging-%: copy-app-$(APP)
+	@for v in $(APP_STAGING_ENV_$(APP)) ; do \
+		sed -i -e "s,$${v/\=/,},g" $(APP_TMP)/bundle.js ; \
+	done
+
+configure-production-%: copy-app-$(APP)
+	@for v in $(APP_PRODUCTION_ENV_$(APP)) ; do \
+		sed -i -e "s,$${v/\=/,},g" $(APP_TMP)/bundle.js ; \
+	done
 
 build-docker: require-APP build-docker-$(APP)
 
 build-docker-%: nix
 	nix-build nix/docker.nix -A $(subst build-docker-,,$@) -o result-docker-$(subst build-docker-,,$@) --fallback
-
-
 
 
 deploy-staging-all: $(foreach app, $(APPS), deploy-staging-$(app))
@@ -143,12 +162,14 @@ deploy-staging-HEROKU: require-APP require-HEROKU build-tool-push build-docker-$
 		-N $(APP_STAGING_HEROKU_$(APP))/web \
 		-T latest
 
-deploy-staging-S3: require-AWS require-APP build-tool-awscli build-app-$(APP)
+deploy-staging-S3: require-AWS require-APP build-tool-awscli build-app-$(APP) configure-staging-$(APP)
 	./result-tool-awscli/bin/aws s3 sync \
 		--delete \
 		--acl public-read  \
-		result-$(APP)/ \
+		$(APP_TMP) \
 		s3://$(APP_STAGING_S3_$(APP))
+
+	rm -rf $(APP_TMP)
 
 deploy-staging-releng_docs: deploy-staging-S3
 deploy-staging-releng_frontend: deploy-staging-S3
@@ -173,7 +194,7 @@ deploy-production-HEROKU: require-APP require-HEROKU build-tool-push build-docke
 		-N $(APP_PRODUCTION_HEROKU_$(APP))/web \
 		-T latest
 
-deploy-production-S3: require-AWS require-APP build-tool-awscli build-app-$(APP)
+deploy-production-S3: require-AWS require-APP build-tool-awscli build-app-$(APP) configure-production-$(APP)
 	./result-tool-awscli/bin/aws s3 sync \
 		--delete \
 		--acl public-read  \

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -6,7 +6,11 @@ require('bootstrap');
 var Hawk = require('hawk');
 require("./index.scss");
 
-var backend_dashboard_url = process.env.NEO_DASHBOARD_URL || "REAL_DASHBOARD_URL";
+// Load backend url from process (dev) or html element (staging/prod)
+var backend_dashboard_url = process.env.NEO_DASHBOARD_URL;
+var root = document.getElementById('root');
+if(!backend_dashboard_url && root)
+  backend_dashboard_url = root.getAttribute('data-dashboard-url');
 
 var storage_key = 'shipit-credentials';
 

--- a/src/shipit_frontend/src/index.js
+++ b/src/shipit_frontend/src/index.js
@@ -6,7 +6,7 @@ require('bootstrap');
 var Hawk = require('hawk');
 require("./index.scss");
 
-var backend_dashboard_url = process.env.NEO_DASHBOARD_URL || "http://localhost:5000";
+var backend_dashboard_url = process.env.NEO_DASHBOARD_URL || "REAL_DASHBOARD_URL";
 
 var storage_key = 'shipit-credentials';
 
@@ -24,7 +24,7 @@ app.ports.localstorage_load.subscribe(function(){
     user = JSON.parse(window.localStorage.getItem(storage_key));
     user = user.value || user;
   } catch (e) {
-    console.warn('Loading user failed', e);
+    user = null;
   }
   app.ports.localstorage_get.send(user);
 });


### PR DESCRIPTION
This patch adds a step after building a js app in the makefile, in order to configure the backend (or any other setting in the bundle).
Any variable set in `APP_STAGING_ENV_appname` or `APP_PRODUCTION_ENV_appname` will be replaced directly in the bundle before deployment