### PR TITLE
renaming swagger.yml to api.yml

### DIFF
--- a/src/releng_clobberer/releng_clobberer/__init__.py
+++ b/src/releng_clobberer/releng_clobberer/__init__.py
@@ -20,7 +20,7 @@ APP_SETTINGS = os.path.abspath(os.path.join(HERE, '..', 'settings.py'))
 
 def init_app(app):
     return app.api.register(
-        os.path.join(os.path.dirname(__file__), 'swagger.yml'))
+        os.path.join(os.path.dirname(__file__), 'api.yml'))
 
 
 if DEBUG and not os.environ.get('DATABASE_URL'):

--- a/src/releng_clobberer/releng_clobberer/api.yml
+++ b/src/releng_clobberer/releng_clobberer/api.yml
@@ -3,6 +3,10 @@ swagger: "2.0"
 info:
   version: "1.0.0"
   title: "Clobberer"
+consumes:
+  - application/json
+produces:
+  - application/json
 paths:
 
   /buildbot:

--- a/src/releng_tooltool/releng_tooltool/__init__.py
+++ b/src/releng_tooltool/releng_tooltool/__init__.py
@@ -17,7 +17,7 @@ APP_SETTINGS = os.path.abspath(os.path.join(HERE, '..', 'settings.py'))
 
 def init_app(app):
     return app.api.register(
-        os.path.join(os.path.dirname(__file__), 'swagger.yml'))
+        os.path.join(os.path.dirname(__file__), 'api.yml'))
 
 
 if DEBUG and not os.environ.get('DATABASE_URL'):

--- a/src/releng_tooltool/releng_tooltool/api.yml
+++ b/src/releng_tooltool/releng_tooltool/api.yml
@@ -3,6 +3,10 @@ swagger: "2.0"
 info:
   version: "1.0.0"
   title: "ToolTool"
+consumes:
+ - application/json
+produces:
+ - application/json
 paths:
 
   /upload:

--- a/src/shipit_dashboard/shipit_dashboard/__init__.py
+++ b/src/shipit_dashboard/shipit_dashboard/__init__.py
@@ -23,7 +23,7 @@ def init_app(app):
 
     # Register swagger api
     return app.api.register(
-        os.path.join(os.path.dirname(__file__), 'swagger.yml'))
+        os.path.join(os.path.dirname(__file__), 'api.yml'))
 
 if not os.environ.get('APP_SETTINGS') and \
        os.path.isfile(APP_SETTINGS):

--- a/src/shipit_dashboard/shipit_dashboard/api.yml
+++ b/src/shipit_dashboard/shipit_dashboard/api.yml
@@ -3,6 +3,10 @@ swagger: "2.0"
 info:
   version: "0.1.0"
   title: "Shipit Dashboard"
+consumes:
+ - application/json
+produces:
+ - application/json
 paths:
 
   /analysis:


### PR DESCRIPTION
motivation behind this is that in longer term swagger (the name) is going to be replaced by OpenApi ... we can just use the correct name. i have also seen other projects using ``api.yml`` so it is kind of non-written convention.

i've also added constrains that this are only json api endpoints