### PR TITLE
Add mochitest-clipboard checkbox to the trychooser page

### DIFF
--- a/src/releng_frontend/src/trychooser/index.html
+++ b/src/releng_frontend/src/trychooser/index.html
@@ -262,6 +262,7 @@
                             <input type="checkbox" value="mochitest-browser-screenshots">mochitest-browser-screenshots
                         </label>
                     </li>
+                    <li><label><input type="checkbox" value="mochitest-clipboard">mochitest-clipboard</label></li>
                     <li><label><input type="checkbox" value="mochitest-dt">mochitest-dt (devtools)</label></li>
                     <li><label><input type="checkbox" value="mochitest-o">mochitest-o (other)</label></li>
                     <li><label><input type="checkbox" value="mochitest-media">mochitest-mda (dom/media)</label></li>


### PR DESCRIPTION
Let me specify a "mochitest-clipboard" option as part of the try command line.
Will run the "cl" suite.