### PR TITLE
Shipit dashboard: use postgres:// prefix instead of postgresql://

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,7 @@ require-sqlite: nix require-APP
 	@echo "Using sqlite dev database $(DATABASE_URL)"
 
 require-postgres: nix require-APP
-	$(eval export DATABASE_URL=postgresql://localhost:$(APP_DEV_POSTGRES_PORT)/$(APP))
+	$(eval export DATABASE_URL=postgres://localhost:$(APP_DEV_POSTGRES_PORT)/$(APP))
 	@echo "Using postgresql dev database $(DATABASE_URL)"
 
 

--- a/src/shipit_dashboard/settings.py
+++ b/src/shipit_dashboard/settings.py
@@ -21,8 +21,8 @@ if 'REDIS_URL' in os.environ:
 
 if not DATABASE_URL:
     raise Exception("You need to specify DATABASE_URL variable.")
-if not DATABASE_URL.startswith('postgresql://'):
-    raise Exception('Shipit dashboard needs a postgresql:// DATABASE_URL')
+if not DATABASE_URL.startswith('postgres://'):
+    raise Exception('Shipit dashboard needs a postgres:// DATABASE_URL')
 
 if not CACHE:
     raise Exception("You need to specify CACHE variable.")


### PR DESCRIPTION
Refs #95 