### PR TITLE
Bug 1325719 - Add win32/win64-st-an build options to trychooser

### DIFF
--- a/src/releng_frontend/src/trychooser/index.html
+++ b/src/releng_frontend/src/trychooser/index.html
@@ -106,6 +106,11 @@
                 <span id="build_win32-clang" class="build_queue">N/A</span>
             </li>
             <li>
+                <label><input type="checkbox" name="platform" value="win32-st-an">win32 static analysis</label>
+                <span id="test_win32-st-an" class="test_queue">N/A</span>
+                <span id="build_win32-st-an" class="build_queue">N/A</span>
+            </li>
+            <li>
                 <label><input type="checkbox" name="platform" value="win64">win64</label>
                 <span id="test_win64" class="test_queue">N/A</span>
                 <span id="build_win64" class="build_queue">N/A</span>
@@ -114,6 +119,11 @@
                 <label><input type="checkbox" name="platform" value="win64-clang">win64-clang</label>
                 <span id="test_win64-clang" class="test_queue">N/A</span>
                 <span id="build_win64-clang" class="build_queue">N/A</span>
+            </li>
+            <li>
+                <label><input type="checkbox" name="platform" value="win64-st-an">win64 static analysis</label>
+                <span id="test_win64-st-an" class="test_queue">N/A</span>
+                <span id="build_win64-st-an" class="build_queue">N/A</span>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="android-api-15">android api 15+</label>


### PR DESCRIPTION
Based on #132 I threw together a patch to fix bug 1325719.

cc @ehsan