### PR TITLE
shipit_bot_uplift: Use robust checkout

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -660,6 +660,109 @@ tasks:
         - "nix-env -iA nixpkgs.gnumake nixpkgs.curl && mkdir /src && cd /src && curl -L https://github.com/mozilla-releng/services/archive/$GITHUB_HEAD_SHA.tar.gz -o $GITHUB_HEAD_SHA.tar.gz && tar zxf $GITHUB_HEAD_SHA.tar.gz && cd services-$GITHUB_HEAD_SHA && ./.taskcluster.sh"
 
 
+# --- shipit_bot_uplift (master) ---
+
+  - metadata:
+      name: "shipit_bot_uplift"
+      description: "Test, build and deploy shipit_bot_uplift"
+      owner: "{{ event.head.user.email }}"
+      source: "https://github.com/mozilla-releng/services/tree/master/src/shipit_bot_uplift"
+    scopes:
+      - secrets:get:repo:github.com/mozilla-releng/services:branch:master
+      - hooks:modify-hook:project-releng/services-master-shipit_bot_uplift-*
+      - assume:hook-id:project-releng/services-master-shipit_bot_uplift-*
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.*
+          - push
+        branches:
+          - master
+    provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    payload:
+      maxRunTime: 7200 # seconds (i.e. two hours)
+      image: "nixos/nix:latest"
+      features:
+        taskclusterProxy: true
+      env:
+        APP: "shipit_bot_uplift"
+        TASKCLUSTER_SECRETS: "taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/services:branch:master"
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "nix-env -iA nixpkgs.gnumake nixpkgs.curl && mkdir /src && cd /src && curl -L https://github.com/mozilla-releng/services/archive/$GITHUB_HEAD_SHA.tar.gz -o $GITHUB_HEAD_SHA.tar.gz && tar zxf $GITHUB_HEAD_SHA.tar.gz && cd services-$GITHUB_HEAD_SHA && ./.taskcluster.sh"
+
+
+# --- shipit_bot_uplift (staging) ---
+
+  - metadata:
+      name: "shipit_bot_uplift"
+      description: "Test, build and deploy shipit_bot_uplift"
+      owner: "{{ event.head.user.email }}"
+      source: "https://github.com/mozilla-releng/services/tree/staging/src/shipit_bot_uplift"
+    scopes:
+      - secrets:get:repo:github.com/mozilla-releng/services:branch:staging
+      - hooks:modify-hook:project-releng/services-staging-shipit_bot_uplift-*
+      - assume:hook-id:project-releng/services-staging-shipit_bot_uplift-*
+    extra:
+      github:
+        env: true
+        events:
+          - push
+        branches:
+          - staging
+    provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    payload:
+      maxRunTime: 7200 # seconds (i.e. two hours)
+      image: "nixos/nix:latest"
+      features:
+        taskclusterProxy: true
+      env:
+        APP: "shipit_bot_uplift"
+        TASKCLUSTER_SECRETS: "taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/services:branch:staging"
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "nix-env -iA nixpkgs.gnumake nixpkgs.curl && mkdir /src && cd /src && curl -L https://github.com/mozilla-releng/services/archive/$GITHUB_HEAD_SHA.tar.gz -o $GITHUB_HEAD_SHA.tar.gz && tar zxf $GITHUB_HEAD_SHA.tar.gz && cd services-$GITHUB_HEAD_SHA && ./.taskcluster.sh"
+
+
+# --- shipit_bot_uplift (production) ---
+
+  - metadata:
+      name: "shipit_bot_uplift"
+      description: "Test, build and deploy shipit_bot_uplift"
+      owner: "{{ event.head.user.email }}"
+      source: "https://github.com/mozilla-releng/services/tree/production/src/shipit_bot_uplift"
+    scopes:
+      - secrets:get:repo:github.com/mozilla-releng/services:branch:production
+      - hooks:modify-hook:project-releng/services-production-shipit_bot_uplift-*
+      - assume:hook-id:project-releng/services-production-shipit_bot_uplift-*
+    extra:
+      github:
+        env: true
+        events:
+          - push
+        branches:
+          - production
+    provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    payload:
+      maxRunTime: 7200 # seconds (i.e. two hours)
+      image: "nixos/nix:latest"
+      features:
+        taskclusterProxy: true
+      env:
+        APP: "shipit_bot_uplift"
+        TASKCLUSTER_SECRETS: "taskcluster/secrets/v1/secret/repo:github.com/mozilla-releng/services:branch:production"
+      command:
+        - "/bin/bash"
+        - "-c"
+        - "nix-env -iA nixpkgs.gnumake nixpkgs.curl && mkdir /src && cd /src && curl -L https://github.com/mozilla-releng/services/archive/$GITHUB_HEAD_SHA.tar.gz -o $GITHUB_HEAD_SHA.tar.gz && tar zxf $GITHUB_HEAD_SHA.tar.gz && cd services-$GITHUB_HEAD_SHA && ./.taskcluster.sh"
+
+
 # --- shipit_dashboard (master) ---
 
   - metadata:

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ deploy-staging-releng_archiver:        deploy-staging-HEROKU
 
 deploy-staging-shipit_frontend:        deploy-staging-S3
 deploy-staging-shipit_dashboard:       deploy-staging-HEROKU
+deploy-staging-shipit_bot_uplift:   	 # There is no service running, just a hook
 deploy-staging-shipit_pipeline:        # deploy-staging-HEROKU
 deploy-staging-shipit_signoff:         # deploy-staging-HEROKU
 
@@ -330,6 +331,7 @@ deploy-production-releng_archiver:     # deploy-production-HEROKU
 
 deploy-production-shipit_frontend:     deploy-production-S3
 deploy-production-shipit_dashboard:    deploy-production-HEROKU
+deploy-production-shipit_bot_uplift:   # There is no service running, just a hook
 deploy-production-shipit_pipeline:     # deploy-staging-HEROKU
 deploy-production-shipit_signoff:      # deploy-staging-HEROKU
 

--- a/src/releng_docs/services_shipit.rst
+++ b/src/releng_docs/services_shipit.rst
@@ -1,0 +1,59 @@
+.. _services-shipit:
+
+Service family: ``src/shipit_*``
+================================
+
+Shipit service family is a collection of smaller services with a common
+frontend (``src/shipit_frontend``) interface.
+
+
+``src/shipit_frontend``
+-----------------------
+
+:staging: https://shipit.staging.mozilla-releng.net
+:production: https://shipit.mozilla-releng.net
+
+Shipit frontend is a web interface, written in Elm, displaying to Mozilla Release Managers informations about:
+
+- uplift requests for bugs on each Firefox release stage (Aurora, Beta, Release and ESR)
+- automated merge tests
+- detailed contributors informations
+
+The goal of this project is to be fast, nice looking and always having up-to-date informations from multiple sources (Mozilla bugzilla, mercurial repository, patch analysis, ...)
+
+
+``src/shipit_dashboard``
+------------------------
+
+:staging: https://dashboard.shipit.staging.mozilla-releng.net
+:production: https://dashboard.shipit.mozilla-releng.net
+
+Shipit Dashboard is the backend service storing and serving bug analysis for each Mozilla Firefox release versions: it's used by Shipit frontend.
+
+Architecture:
+
+- Python backend, written with Flask
+- Hosted on Heroku (a dyno and Postgresql database)
+- Stores analysis as Json in the postgresql database
+- Authentication through Taskcluster (no local users)
+
+.. note::
+
+    There is no analysis or long running task in shipit dasthboard. It "just" stores data and serves it through a REST api.
+
+
+``src/shipit_bot_uplift``
+-------------------------
+
+Shipit bot uplift is not a service, it's a Python bot, runnning as a Taskcluster hook every 30 minutes.
+It does the following tasks on every run:
+
+- Update a cached clone of mozilla-unified repository
+- List current bugs on shipit_dashboard
+- List current bugs for every release versions with an uplift request on Bugzilla
+- Run a full bug analysis using libmozdata_ on every new bug (or bugs needing an update)
+- Try to merge (through Mercurial graft) every patch in an uplift request
+- Report the full analysis to shipit dashboard, so it can be displayed on shipit frontend.
+
+
+.. _libmozdata: https://github.com/mozilla/libmozdata/

--- a/src/shipit_bot_uplift/default.nix
+++ b/src/shipit_bot_uplift/default.nix
@@ -119,7 +119,7 @@ let
   mkBot = branch :
     let
       cacheKey = "shipit-bot-" + branch;
-      secretsKey = "project/shipit/bot/" + branch;
+      secretsKey = "repo:github.com/mozilla-releng/services:branch:" + branch;
     in
       mkTaskclusterHook {
         name = "Shipit bot updating bug analysis";

--- a/src/shipit_bot_uplift/default.nix
+++ b/src/shipit_bot_uplift/default.nix
@@ -169,7 +169,8 @@ let
         python.packages.click
         python.packages.mohawk
         python.packages.taskcluster
-				releng_pkgs.pkgs.mercurial
+        python.packages.robustcheckout
+        python.packages.mercurial
       ];
     passthru = {
       taskclusterHooks = {

--- a/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
@@ -258,7 +258,7 @@ class Bot(object):
         # Init local copy of mozilla-unified
         self.repository = Repository(
             'https://hg.mozilla.org/mozilla-unified',
-            os.path.join(cache_root, 'mozilla-unified')
+            cache_root,
         )
 
     def list_bugs(self, query):
@@ -409,7 +409,7 @@ class BotRemote(Bot):
             'Missing mozilla repository'
 
         # First update local repository
-        self.repository.update()
+        self.repository.checkout('release')
 
         # Load all analysis
         all_analysis = self.make_request('get', '/analysis')
@@ -450,6 +450,7 @@ class BotRemote(Bot):
             'Use BugSync instance'
 
         # Do patch analysis on bugs
+        logger.info('Started bug analysis', bz_id=sync.bugzilla_id)
         if not sync.update():
             return
 

--- a/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
@@ -301,16 +301,16 @@ class BotRemote(Bot):
 
         # Setup credentials for Shipit api
         self.credentials = {
-          'id': secrets['client_id'],
-          'key': secrets['access_token'],
+          'id': secrets['TASKCLUSTER_CLIENT_ID'],
+          'key': secrets['TASKCLUSTER_ACCESS_TOKEN'],
           'algorithm': 'sha256',
         }
 
         super(BotRemote, self).__init__(
-            secrets['bugzilla_url'],
-            secrets['bugzilla_token']
+            secrets['BUGZILLA_URL'],
+            secrets['BUGZILLA_TOKEN']
         )
-        self.api_url = secrets['api_url']
+        self.api_url = secrets['API_URL']
         self.sync = {}  # init
 
     def load_secrets(self, secrets_path, client_id=None, access_token=None):
@@ -345,16 +345,16 @@ class BotRemote(Bot):
         # Check mandatory keys in secrets
         secrets = tc.get(secrets_path)
         secrets = secrets['secret']
-        required = ('bugzilla_url', 'bugzilla_token', 'api_url')
+        required = ('BUGZILLA_URL', 'BUGZILLA_TOKEN', 'API_URL')
         for req in required:
             if req not in secrets:
                 raise Exception('Missing value {} in Taskcluster secret value {}'.format(req, secrets_path))  # noqa
 
         # Add credentials too
-        if 'client_id' not in secrets:
-            secrets['client_id'] = client_id
-        if 'access_token' not in secrets:
-            secrets['access_token'] = access_token
+        if 'TASKCLUSTER_CLIENT_ID' not in secrets:
+            secrets['TASKCLUSTER_CLIENT_ID'] = client_id
+        if 'TASKCLUSTER_ACCESS_TOKEN' not in secrets:
+            secrets['TASKCLUSTER_ACCESS_TOKEN'] = access_token
 
         return secrets
 

--- a/src/shipit_dashboard/default.nix
+++ b/src/shipit_dashboard/default.nix
@@ -11,7 +11,7 @@ let
   python = import ./requirements.nix { inherit (releng_pkgs) pkgs; };
   releng_common = import ./../../lib/releng_common {
     inherit releng_pkgs python;
-    extras = ["api" "auth" "cors" "log" "db" ];
+    extras = ["api" "auth" "cors" "log" "db" "security" ];
   };
 
   self = mkBackend rec {

--- a/src/shipit_dashboard/requirements.txt
+++ b/src/shipit_dashboard/requirements.txt
@@ -1,3 +1,3 @@
--e ../../lib/releng_common[api,auth,cors,log,db]
+-e ../../lib/releng_common[api,auth,cors,log,db,security]
 
 -e .

--- a/src/shipit_dashboard/requirements_frozen.txt
+++ b/src/shipit_dashboard/requirements_frozen.txt
@@ -12,15 +12,16 @@ flake8==3.2.1
 Flask==0.12
 Flask-Cors==3.0.2
 Flask-Login==0.4.0
-Flask-Migrate==2.0.2
+Flask-Migrate==2.0.3
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
+flask-talisman==0.2.1
 gunicorn==19.6.0
 ipdb==0.10.2
-ipython==5.1.0
+ipython==5.2.1
 ipython-genutils==0.1.0
 itsdangerous==0.24
-Jinja2==2.9.4
+Jinja2==2.9.5
 jsonschema==2.5.1
 Logbook==1.0.0
 Mako==1.0.6
@@ -32,7 +33,7 @@ newrelic==2.78.0.57
 packaging==16.8
 pexpect==4.2.1
 pickleshare==0.7.4
-prompt-toolkit==1.0.9
+prompt-toolkit==1.0.10
 psycopg2==2.6.2
 ptyprocess==0.5.1
 py==1.4.32
@@ -41,7 +42,7 @@ pyflakes==1.3.0
 Pygments==2.2.0
 pyparsing==2.1.10
 pytest==3.0.6
-pytest-runner==2.10.1
+pytest-runner==2.11
 python-editor==1.0.3
 PyYAML==3.12
 requests==2.13.0
@@ -54,7 +55,7 @@ SQLAlchemy==1.1.5
 strict-rfc3339==0.7
 structlog==16.1.0
 swagger-spec-validator==2.0.2
-taskcluster==0.3.4
+taskcluster==1.0.2
 traitlets==4.3.1
 vcversioner==2.16.0.0
 wcwidth==0.1.7

--- a/src/shipit_dashboard/requirements_generated.nix
+++ b/src/shipit_dashboard/requirements_generated.nix
@@ -73,10 +73,10 @@ self: {
 
 
   "Flask-Migrate" = python.mkDerivation {
-    name = "Flask-Migrate-2.0.2";
+    name = "Flask-Migrate-2.0.3";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/f8/ba/827214fb932fb1de1fac7d992f0958c799bfc50ea471b0b8792d5e72daa6/Flask-Migrate-2.0.2.tar.gz";
-      sha256 = "c77272b936ec94209d5c709f9ec43947f4a25513c1b12cc25241586abdfa84b1";
+      url = "https://pypi.python.org/packages/a9/fe/559c313679b08f67efb9fba6f01debbc9ea3a488539d03a5a38371351456/Flask-Migrate-2.0.3.tar.gz";
+      sha256 = "331f1facf93712b6a3067eac382e645b1ef09e9a6d34da447acb6a3c293afd80";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
@@ -137,10 +137,10 @@ self: {
 
 
   "Jinja2" = python.mkDerivation {
-    name = "Jinja2-2.9.4";
+    name = "Jinja2-2.9.5";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/f4/3f/28387a5bbc6883082c16784c6135440b94f9d5938fb156ff579798e18eda/Jinja2-2.9.4.tar.gz";
-      sha256 = "aab8d8ca9f45624f1e77f2844bf3c144d180e97da8824c2a6d7552ad039b5442";
+      url = "https://pypi.python.org/packages/71/59/d7423bd5e7ddaf3a1ce299ab4490e9044e8dfd195420fc83a24de9e60726/Jinja2-2.9.5.tar.gz";
+      sha256 = "702a24d992f856fa8d5a7a36db6128198d0c21e1da34448ca236c42e92384825";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
@@ -430,7 +430,10 @@ self: {
 
   "connexion" = python.mkDerivation {
     name = "connexion-1.0.129";
-    src = pkgs.fetchurl { url = "https://pypi.python.org/packages/ca/b1/1b40f5ba85b275bfc1878d030722809281e4a6f05c62b75abba3861be9f7/connexion-1.0.129.tar.gz"; sha256 = "dbee8e66c66c09e0db3083bd40f6c2c1a6ae193e06bb57c48202642429da70ad"; };
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/ca/b1/1b40f5ba85b275bfc1878d030722809281e4a6f05c62b75abba3861be9f7/connexion-1.0.129.tar.gz";
+      sha256 = "dbee8e66c66c09e0db3083bd40f6c2c1a6ae193e06bb57c48202642429da70ad";
+    };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
     propagatedBuildInputs = [
@@ -510,6 +513,26 @@ self: {
 
 
 
+  "flask-talisman" = python.mkDerivation {
+    name = "flask-talisman-0.2.1";
+    src = pkgs.fetchurl {
+      url = "https://pypi.python.org/packages/46/4b/1e523f46e0a29b9f0f05f19c6d18c3872ba5c128a39a00c4d1b1d46f9178/flask-talisman-0.2.1.tar.gz";
+      sha256 = "9fb9aa9e9b905bc511f2346c579cd824bf7fc8562225ff20e8e7a142d883c754";
+    };
+    doCheck = commonDoCheck;
+    buildInputs = commonBuildInputs;
+    propagatedBuildInputs = [
+      self."six"
+    ];
+    meta = with pkgs.stdenv.lib; {
+      homepage = "";
+      license = "License :: OSI Approved :: Apache Software License";
+      description = "HTTP security headers for Flask.";
+    };
+  };
+
+
+
   "gunicorn" = python.mkDerivation {
     name = "gunicorn-19.6.0";
     src = pkgs.fetchurl {
@@ -549,10 +572,10 @@ self: {
 
 
   "ipython" = python.mkDerivation {
-    name = "ipython-5.1.0";
+    name = "ipython-5.2.1";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/89/63/a9292f7cd9d0090a0f995e1167f3f17d5889dcbc9a175261719c513b9848/ipython-5.1.0.tar.gz";
-      sha256 = "7ef4694e1345913182126b219aaa4a0047e191af414256da6772cf249571b961";
+      url = "https://pypi.python.org/packages/e7/75/7c981d2d7f25754ef64f955b595c2d80e2fec1aa47e52bd55ab35dbc8ccf/ipython-5.2.1.tar.gz";
+      sha256 = "04dafc37c8876e10e797264302e4333dbcd2854ef6d16bb57cc12ce26515bfdb";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
@@ -765,10 +788,10 @@ self: {
 
 
   "prompt-toolkit" = python.mkDerivation {
-    name = "prompt-toolkit-1.0.9";
+    name = "prompt-toolkit-1.0.10";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/83/14/5ac258da6c530eca02852ee25c7a9ff3ca78287bb4c198d0d0055845d856/prompt_toolkit-1.0.9.tar.gz";
-      sha256 = "cd6523b36adc174cc10d54b1193eb626b4268609ff6ea92c15bcf1996609599c";
+      url = "https://pypi.python.org/packages/3e/e9/bc909966f2091e0a00952402c59cc6590c96de71fb97cc2d502b0d5916c5/prompt_toolkit-1.0.10.tar.gz";
+      sha256 = "dcc056c506e977e3679dc4d53bc66223111d16e09b506b4336f60ea6b530a670";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
@@ -914,10 +937,10 @@ self: {
 
 
   "pytest-runner" = python.mkDerivation {
-    name = "pytest-runner-2.10.1";
+    name = "pytest-runner-2.11";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/3d/dd/e491ac188a79b4d18628b1f9aa5df3603be72c3a02ae3e1dd5e081cb7ccc/pytest-runner-2.10.1.tar.gz";
-      sha256 = "ecc9549ed1ce9bbfc9e7c9bad33d3f9fa91da2334632070a191a35aa96f0be35";
+      url = "https://pypi.python.org/packages/f8/f9/d740d06d15c1bce86ff7a0502e3da116944efecc61a5cfffedd356f19675/pytest-runner-2.11.tar.gz";
+      sha256 = "bd4cae2efe03495955197983695cc170b5060766f9245994a8cda1ffc7fd3123";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
@@ -1123,15 +1146,16 @@ self: {
 
 
   "taskcluster" = python.mkDerivation {
-    name = "taskcluster-0.3.4";
+    name = "taskcluster-1.0.2";
     src = pkgs.fetchurl {
-      url = "https://pypi.python.org/packages/3e/50/bb7659d5cf396f5c78013bb35ac92931c852b0ae3fa738bbd9224b6192ef/taskcluster-0.3.4.tar.gz";
-      sha256 = "d4fe5e2a44fe27e195b92830ece0a6eb9eb7ad9dc556a0cb16f6f2a6429f1b65";
+      url = "https://pypi.python.org/packages/d8/00/aac389ae5f2db76b029d55d36d394e272486894d155073369c4e0b272619/taskcluster-1.0.2.tar.gz";
+      sha256 = "11cfd462a333e0a084f94c9ce55e349036dbcf04656767f9773da7d148aa5115";
     };
     doCheck = commonDoCheck;
     buildInputs = commonBuildInputs;
     propagatedBuildInputs = [
       self."aiohttp"
+      self."async-timeout"
       self."mohawk"
       self."requests"
       self."six"

--- a/src/shipit_dashboard/setup.py
+++ b/src/shipit_dashboard/setup.py
@@ -26,7 +26,7 @@ setup(
         'pytest',
     ],
     install_requires=[
-        'releng_common[log,api,cors,auth,db]',
+        'releng_common[log,api,cors,auth,db,security]',
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
As recommended by Gregory Szorc, i simplified the mercurial branch checkout process by using the Mozilla extension [robustcheckout](https://hg.mozilla.org/hgcustom/version-control-tools/file/tip/hgext/robustcheckout/__init__.py)