### PR TITLE
Move 10.6 and XP into a legacy group so people stop selecting them

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -198,16 +198,9 @@
               <label><input type="checkbox" value="Ubuntu,-x64">linux32</label>
             </li>
 
-            <li>
-              <label><input type="checkbox" value="10.6">OSX 10.6 <a href="https://bugzil.la/1269790">crashes if you aren't pushing esr45</a></label>
-            </li>
 
             <li>
               <label><input type="checkbox" value="10.10">OSX 10.10</label>
-            </li>
-
-            <li>
-              <label><input type="checkbox" value="Windows XP">WinXP (win32) - <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1219434">disabled when not explicitly checked</a></label>
             </li>
 
             <li>
@@ -220,6 +213,21 @@
 
             <li>
               <label><input type="checkbox" value="Android 4.3">Android 4.3 API15+</label>
+            </li>
+
+            </ul>
+            </div>
+
+            <div class='option-group' id='tee-legacy-platforms' try-filter='u'>
+            <label>Legacy test platforms (disabled by default)</label>
+            <ul>
+
+            <li>
+              <label><input type="checkbox" value="10.6">OSX 10.6 - <a href="https://bugzil.la/1269790">esr45 only</a></label>
+            </li>
+
+            <li>
+              <label><input type="checkbox" value="Windows XP">WinXP (win32) - <a href="https://bugzili.la/1219434">Firefox 52 and earlier only</a></label>
             </li>
 
             </ul>


### PR DESCRIPTION
This is generating unnecessary traffic on Try when people just click all the things.