### PR TITLE
Add Dockerfile + docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM nixos/nix:1.11
+
+ENV NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/fa4167c0a13cbe0d97b9c88d91b86845a8c4e740.tar.gz"
+
+COPY nix/nix.conf /etc/nix/nix.conf
+COPY .git/ /app/.git/
+COPY lib/ /app/lib/
+COPY nix/ /app/nix/
+COPY src/ /app/src/
+COPY VERSION /app/
+
+RUN nix-channel --update
+# TODO: remove downloaded packages
+RUN nix-env -iA nixpkgs.nix nixpkgs.cacert nixpkgs.git nixpkgs.gnumake \
+ && nix-collect-garbage -d
+
+RUN cd /app && nix-shell nix/default.nix -A releng_frontend --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A releng_clobberer --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A releng_tooltool --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A releng_treestatus --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A releng_mapper --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A releng_archiver --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A shipit_bot_uplift --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A shipit_dashboard --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A shipit_frontend --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A shipit_pipeline --run "exit"
+RUN cd /app && nix-shell nix/default.nix -A shipit_signoff --run "exit"
+
+# Doing this after all the nix installation means rebuilds are faster for Makefile-only changes
+COPY Makefile /app/
+
+WORKDIR /app
+ENTRYPOINT ["/root/.nix-profile/bin/make"]
+CMD ["docker-run", "APP=${SERVICES_APP}"]

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ VERSION=$(shell cat VERSION)
 
 APP_DEV_DBNAME=services
 
-APP_DEV_HOST=0.0.0.0
+APP_DEV_HOST?=localhost
 
 APP_DEV_PORT_releng_docs=7000
 APP_DEV_PORT_elm_common_example=7001

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ VERSION=$(shell cat VERSION)
 
 APP_DEV_DBNAME=services
 
-APP_DEV_HOST=localhost
+APP_DEV_HOST=0.0.0.0
 
 APP_DEV_PORT_releng_docs=7000
 APP_DEV_PORT_elm_common_example=7001
@@ -158,11 +158,7 @@ nix:
 		echo ""; \
 		echo "This Makefile uses Nix packages to run commands in an isolated environment."; \
 		echo ""; \
-		echo "To install Nix please follow instructions on https://nixos.org/nix/"; \
-		echo ""; \
-		echo "For inpatients, run the following curl-bash"; \
-		echo ""; \
-		echo "$$ curl https://nixos.org/nix/install | sh; . \$$HOME/.nix-profile/etc/profile.d/nix.sh"; \
+		echo "To install Nix please follow instructions on https://docs.mozilla-releng.net/prerequirements.html#prerequirements"; \
 		echo ""; \
 		echo "and rerun the same command again"; \
 		echo ""; \
@@ -177,6 +173,7 @@ develop: nix require-APP
 
 
 develop-run: require-APP develop-run-$(APP)
+docker-run: require-APP docker-run-$(APP)
 
 develop-run-SPHINX : nix require-APP
 	nix-shell nix/default.nix -A releng_docs --run "HOST=$(APP_DEV_HOST) PORT=$(APP_DEV_PORT_$(APP)) python run.py"
@@ -208,6 +205,18 @@ develop-run-shipit_frontend: develop-run-FRONTEND
 develop-run-shipit_dashboard: require-postgres develop-run-BACKEND
 develop-run-shipit_pipeline: require-sqlite develop-run-BACKEND
 develop-run-shipit_signoff: require-sqlite develop-run-BACKEND
+
+docker-run-releng_frontend: develop-run-FRONTEND
+docker-run-releng_clobberer: require-sqlite develop-run-BACKEND
+docker-run-releng_tooltool: require-sqlite develop-run-BACKEND
+docker-run-releng_treestatus: develop-run-BACKEND
+docker-run-releng_mapper: require-sqlite develop-run-BACKEND
+docker-run-releng_archiver: require-sqlite develop-run-BACKEND
+
+docker-run-shipit_frontend: develop-run-FRONTEND
+docker-run-shipit_dashboard: develop-run-BACKEND
+docker-run-shipit_pipeline: require-sqlite develop-run-BACKEND
+docker-run-shipit_signoff: require-sqlite develop-run-BACKEND
 
 develop-run-postgres: build-postgresql require-initdb
 	./result-tool-postgresql/bin/postgres -D $(PWD)/tmp/postgres -h localhost -p $(APP_DEV_POSTGRES_PORT)

--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,8 @@ docker-run-releng_archiver: require-sqlite develop-run-BACKEND
 
 docker-run-shipit_frontend: develop-run-FRONTEND
 docker-run-shipit_dashboard: develop-run-BACKEND
-docker-run-shipit_pipeline: require-sqlite develop-run-BACKEND
-docker-run-shipit_signoff: require-sqlite develop-run-BACKEND
+docker-run-shipit_pipeline: develop-run-BACKEND
+docker-run-shipit_signoff: develop-run-BACKEND
 
 develop-run-postgres: build-postgresql require-initdb
 	./result-tool-postgresql/bin/postgres -D $(PWD)/tmp/postgres -h localhost -p $(APP_DEV_POSTGRES_PORT)

--- a/docker-compose-releng.yml
+++ b/docker-compose-releng.yml
@@ -1,0 +1,84 @@
+version: "2.1"
+
+# TODO: what links do we need?
+services:
+  releng_db:
+    image: postgres:9.6
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_PASSWORD=releng
+      - POSTGRES_USER=releng
+      - POSTGRES_DB=releng
+    volumes:
+      - ./tmp/postgres:/var/lib/postgresql/data
+
+  releng_frontend:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_frontend
+
+  releng_clobberer:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8001:8001"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_clobberer
+
+  releng_tooltool:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8002:8002"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_tooltool
+
+  releng_treestatus:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8003:8003"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_treestatus
+      - DATABASE_URL=postgresql://releng:releng@releng_db:5432/releng
+    links:
+      - releng_db
+    healthcheck:
+      # TODO: this command generates spamming output from the releng_db container
+      # using the real pg client might fix this
+      test: ["CMD", "nc", "-vz", "releng_db", "5432"]
+      interval: 15s
+      timeout: 2s
+      retries: 10
+
+  releng_mapper:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8004:8004"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_mapper
+
+  releng_archiver:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8005:8005"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=releng_archiver

--- a/docker-compose-releng.yml
+++ b/docker-compose-releng.yml
@@ -3,7 +3,7 @@ version: "2.1"
 # TODO: what links do we need?
 services:
   releng_db:
-    image: postgres:9.6
+    image: postgres@sha256:6ac0fbeddde3bb7b0003a2ace8c126f742f8bdd90695801337d3edaaf1fcc478
     expose:
       - 5432
     environment:
@@ -21,6 +21,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_frontend
 
   releng_clobberer:
@@ -31,6 +32,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_clobberer
 
   releng_tooltool:
@@ -41,6 +43,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_tooltool
 
   releng_treestatus:
@@ -51,6 +54,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_treestatus
       - DATABASE_URL=postgresql://releng:releng@releng_db:5432/releng
     links:
@@ -71,6 +75,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_mapper
 
   releng_archiver:
@@ -81,4 +86,5 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=releng_archiver

--- a/docker-compose-shipit.yml
+++ b/docker-compose-shipit.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   shipit_db:
-    image: postgres:9.6
+    image: postgres@sha256:6ac0fbeddde3bb7b0003a2ace8c126f742f8bdd90695801337d3edaaf1fcc478
     expose:
       - 5432
     environment:
@@ -20,6 +20,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=shipit_frontend
     # The frontend exposes information from each of the backends.
     links:
@@ -37,6 +38,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=shipit_dashboard
       - DATABASE_URL=postgresql://shipit:shipit@shipit_db:5432/shipit
     links:
@@ -59,6 +61,7 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=shipit_pipeline
     # The pipeline service needs to be able to trigger actions in the "step" services
     links:
@@ -75,4 +78,5 @@ services:
       - .:/app
     working_dir: /app
     environment:
+      - APP_DEV_HOST=0.0.0.0
       - SERVICES_APP=shipit_signoff

--- a/docker-compose-shipit.yml
+++ b/docker-compose-shipit.yml
@@ -1,0 +1,78 @@
+version: "2.1"
+
+services:
+  shipit_db:
+    image: postgres:9.6
+    expose:
+      - 5432
+    environment:
+      - POSTGRES_PASSWORD=shipit
+      - POSTGRES_USER=shipit
+      - POSTGRES_DB=shipit
+    volumes:
+      - ./tmp/postgres:/var/lib/postgresql/data
+
+  shipit_frontend:
+    image: mozbhearsum/bhearsum-shipit-test
+    ports:
+      - "8010:8010"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=shipit_frontend
+    # The frontend exposes information from each of the backends.
+    links:
+      - shipit_dashboard
+      - shipit_pipeline
+      - shipit_signoff
+
+  shipit_dashboard:
+    image: mozbhearsum/bhearsum-shipit-test
+    expose:
+      - 8011
+    ports:
+      - "8011:8011"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=shipit_dashboard
+      - DATABASE_URL=postgresql://shipit:shipit@shipit_db:5432/shipit
+    links:
+      - shipit_db
+    healthcheck:
+      # TODO: this command generates spamming output from the shipit_db container
+      # using the real pg client might fix this
+      test: ["CMD", "nc", "-vz", "shipit_db", "5432"]
+      interval: 15s
+      timeout: 2s
+      retries: 10
+
+  shipit_pipeline:
+    image: mozbhearsum/bhearsum-shipit-test
+    expose:
+      - 8012
+    ports:
+      - "8012:8012"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=shipit_pipeline
+    # The pipeline service needs to be able to trigger actions in the "step" services
+    links:
+      - shipit_signoff
+
+  # TODO: might be nice to rename step services to have "step" in their name to make it more obvious
+  shipit_signoff:
+    image: mozbhearsum/bhearsum-shipit-test
+    expose:
+      - 8013
+    ports:
+      - "8013:8013"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      - SERVICES_APP=shipit_signoff

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,0 +1,1 @@
+binary-caches = https://s3.amazonaws.com/releng-cache/ https://cache.nixos.org/

--- a/src/releng_frontend/webpack.config.js
+++ b/src/releng_frontend/webpack.config.js
@@ -36,8 +36,10 @@ config.module.loaders.push({
 config.module.noParse = /\.elm$/;
 
 
-// in development environment use ssl
 if (config_type === 'dev') {
+  // bind to all interfaces, to make docker port forwards work
+  config.devServer.host = "0.0.0.0";
+  // use ssl
   config.devServer.https = true;
   config.devServer.cacert = fs.readFileSync(process.env.SSL_CACERT);
   config.devServer.cert = fs.readFileSync(process.env.SSL_CERT);

--- a/src/shipit_frontend/webpack.config.js
+++ b/src/shipit_frontend/webpack.config.js
@@ -36,8 +36,10 @@ config.module.loaders.push({
 config.module.noParse = /\.elm$/;
 
 
-// in development environment use ssl
 if (config_type === 'dev') {
+  // bind to all interfaces, to make docker port forwards work
+  config.devServer.host = "0.0.0.0";
+  // use ssl
   config.devServer.https = true;
   config.devServer.cacert = fs.readFileSync(process.env.SSL_CACERT);
   config.devServer.cert = fs.readFileSync(process.env.SSL_CERT);


### PR DESCRIPTION
This isn't ready for merging yet, but it's a proof of concept for how we can build a container that lets anyone run the services apps, even if they don't have Nix installed. There's at least a few things todo still:
- Stop hardcoding shipit_frontend everywhere. @garbas has some ideas about dynamically generated docker-compose.yml + Dockerfiles. I'm not entirely convinced that's a great idea, but it's probably worth exploring more. A simple alternative is to allow the APP to be passed in rather than hardcoded in the Dockerfile.
- Fix SSL errors. I think these are caused by something inside the container listening on 127.0.0.1 instead of 0.0.0.0. Jordan previously found a workaround for this (https://people-mozilla.org/~jlund/cert_workaround). I suspect that only the APP_DEV_HOST part is necessary. Need to test this more.
- Test with more apps than shipit_frontend
- Update docker-compose.yml with the right image name/tag once we figure out what those will be.

Once this is merged, we'll need automated builds done and pushed somewhere public. I think dockerhub is probably the best place, because it's where Docker pulls from by default. It's much easier for new folks to get started if they don't need to specify some special host to find the image from.