### PR TITLE
Fix uplift notifications issues

### DIFF
--- a/src/shipit_bot_uplift/shipit_bot_uplift/mercurial.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/mercurial.py
@@ -90,10 +90,12 @@ class Repository(object):
             logger.info('Merge success', revision=revision)
         except hglib.error.CommandError as e:
             logger.warning('Auto merge failed', revision=revision, error=e)  # noqa
-            return False, '{} {}'.format(
+            message = '{} {}'.format(
                 e.out.decode('utf-8'),
                 e.err.decode('utf-8')
             )
+            message = message.replace('\r', '\n')
+            return False, message
 
         # If `hg graft` exits code 0, there are no merge conflicts.
         return True, 'merge success'

--- a/src/shipit_bot_uplift/shipit_bot_uplift/report.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/report.py
@@ -55,7 +55,7 @@ class Report(object):
                         _str(merge_test.revision),
                         _str(merge_test.revision_parent)
                     ),
-                    '```{}```'.format(merge_test.message)
+                    '```\n{}```'.format(merge_test.message)
                 ]
             mail.append('')  # newline
         mail_md = '\n'.join(mail)

--- a/src/shipit_bot_uplift/shipit_bot_uplift/report.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/report.py
@@ -17,6 +17,7 @@ class Report(object):
         self.notify = taskcluster.Notify(tc_options)
         self.emails = emails
         self.merges = set()
+        logger.info('Report notifications', emails=self.emails)
 
     def add_invalid_merge(self, merge_test):
         """

--- a/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
@@ -384,10 +384,8 @@ class BotRemote(Bot):
 
         # Init report
         options = self.build_tc_options('notify/v1', client_id, access_token)
-        self.report = Report(options, [
-            'babadie@mozilla.com',
-            'sledru@mozilla.com',
-        ])
+        emails = secrets.get('UPLIFT_NOTIFICATIONS', ['babadie@mozilla.com'])
+        self.report = Report(options, emails)
 
     def build_tc_options(self, service_endpoint, client_id=None, access_token=None):  # noqa
         """

--- a/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
+++ b/src/shipit_bot_uplift/shipit_bot_uplift/sync.py
@@ -186,8 +186,9 @@ class BugSync(object):
 
         return [
             _link_status(revision, analysis)
-            for revision in self.analysis['patches'].keys()
+            for revision, patch in self.analysis['patches'].items()
             for analysis in self.on_bugzilla
+            if patch['source'] == 'mercurial'
         ]
 
     def build_payload(self, bugzilla_url):


### PR DESCRIPTION
 * Fix #202 by testing only mercurial patches (no attachment)
 * Fix #203 by preserving the newlines
 * Uses TC Secrect to get the notifications email so that @sylvestre does not get both staging & production emails.