### PR TITLE
releng_frontend: add linux64-stylo into restrict tests to platforms

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -200,6 +200,10 @@
             </li>
 
             <li>
+              <label><input type="checkbox" value="linux64-stylo">linux64-stylo</label>
+            </li>
+
+            <li>
               <label><input type="checkbox" value="Ubuntu,-x64">linux32</label>
             </li>
 


### PR DESCRIPTION
This PR is trying to fix [Bug 1347096](https://bugzilla.mozilla.org/show_bug.cgi?id=1347096) because we support the linux64-stylo T-push / π-push already from [Bug 1340911](https://bugzilla.mozilla.org/show_bug.cgi?id=1340911).

e.g. `try: -b do -p all -u all[linux64-stylo] -t none`  This will only push tests on linux64-stylo.

Already verified in https://treeherder.mozilla.org/#/jobs?repo=try&revision=0cc5c32cae1451b87adc8d31529d66666b3aba7d