### PR TITLE
Add first pass on step services API docs

### DIFF
--- a/src/releng_docs/services_shipit.rst
+++ b/src/releng_docs/services_shipit.rst
@@ -3,9 +3,12 @@
 Service family: ``src/shipit_*``
 ================================
 
-Shipit service family is a collection of smaller services with a common
-frontend (``src/shipit_frontend``) interface.
+The Ship It family is a collection of smaller services that help us build, ship, and maintain Releases. There are a few different types of services:
 
+* Frontend - This is where all user interaction with Ship It happens
+* Pipeline - The Pipeline service is responsible for managing the end to end process of shipping a Release
+* Steps - Step services implement discrete parts of a Pipeline
+* Bots - Bots run regularly and are responsible for collecting information required by Ship It
 
 ``src/shipit_frontend``
 -----------------------
@@ -13,7 +16,7 @@ frontend (``src/shipit_frontend``) interface.
 :staging: https://shipit.staging.mozilla-releng.net
 :production: https://shipit.mozilla-releng.net
 
-Shipit frontend is a web interface, written in Elm, displaying to Mozilla Release Managers informations about:
+Ship It frontend is a web interface, written in Elm, displaying to Mozilla Release Managers informations about:
 
 - uplift requests for bugs on each Firefox release stage (Aurora, Beta, Release and ESR)
 - automated merge tests
@@ -28,7 +31,7 @@ The goal of this project is to be fast, nice looking and always having up-to-dat
 :staging: https://dashboard.shipit.staging.mozilla-releng.net
 :production: https://dashboard.shipit.mozilla-releng.net
 
-Shipit Uplift is the backend service storing and serving bug analysis for each Mozilla Firefox release versions: it's used by Shipit frontend.
+Ship It Uplift is the backend service storing and serving bug analysis for each Mozilla Firefox release versions: it's used by Ship It frontend.
 
 Architecture:
 
@@ -39,13 +42,13 @@ Architecture:
 
 .. note::
 
-    There is no analysis or long running task in shipit dasthboard. It "just" stores data and serves it through a REST api.
+    There is no analysis or long running task in shipit dashboard. It "just" stores data and serves it through a REST api.
 
 
 ``src/shipit_bot_uplift``
 -------------------------
 
-Shipit bot uplift is not a service, it's a Python bot, runnning as a Taskcluster hook every 30 minutes.
+Ship It bot uplift is not a service, it's a Python bot, runnning as a Taskcluster hook every 30 minutes.
 It does the following tasks on every run:
 
 - Update a cached clone of mozilla-unified repository
@@ -57,3 +60,44 @@ It does the following tasks on every run:
 
 
 .. _libmozdata: https://github.com/mozilla/libmozdata/
+
+
+``src/shipit_pipeline``
+
+TODO
+
+
+Steps
+-----
+
+Step Services API
+~~~~~~~~~~~~~~~~~
+
+In order to ensure the Pipeline service can successfully managed Steps, each Step Service is required to implement the following API:
+(TODO, flesh this out more)
+
+* /
+** GET - Returns all steps with status (TODO: probably need pagination and filtering here)
+* /{uid}
+** PUT - Create a new Step
+** DELETE - Remove the given Step
+* /{uid}/definition
+** GET Returns the definition of the given step
+* /{uid}/status
+** GET Returns the status of the given step.
+*** Currently, one of: in_progress, success, failure, cancelled
+*** Probably need to add support for including custom service-specific status info.
+
+Step Services are free to add additional endpoints past the required ones.
+
+
+``src/shipit_signoff``
+~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+
+``src/shipit_taskcluster``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO


### PR DESCRIPTION
A few of us met yesterday to talk about what the required HTTP API that step services need to implement would be. This is an attempt to start documenting it. I don't think we've fully decided what it will look like, but this is a start.

Here's a dump from the notes we took yesterday, with some open questions:
* Resource based (supports CRUD operations)
* https://github.com/lundjordan/services/blob/shipit-taskcluster/src/shipit_taskcluster/shipit_taskcluster/api.yml
* All steps support a base interface, some steps may have step-specific interfaces
* need to be careful about allowing step status to be overridden, otherwise we may violate signoff requirements
* pipeline will not be changing step status
* may need additional information returned with some statuses (eg: required/completed signoffs for signoffs steps)
  * or, use a step-specific endpoint for this sort of thing, and leave the main step api alone
* strong case to be made for allowing users to specify uids for pipelines (they can use names like Firefox-53.0-build1)
  * not so strong with steps - too many possible little variations in them, names not as intelligible to humans

Obviously this needs some more updates and fleshing out! What do you think of this so far, @lundjordan?