### PR TITLE
Add rudimentary docs for the signoffs service

### DIFF
--- a/src/releng_docs/run.py
+++ b/src/releng_docs/run.py
@@ -8,7 +8,11 @@ HERE = os.path.dirname(__file__)
 
 server = livereload.Server()
 server.watch(
-    os.path.join(HERE, '*.rst'),
+    os.path.join(HERE, '*'),
+    livereload.shell('make html'),
+)
+server.watch(
+    os.path.join(HERE, 'shipit_signoffs', '*.rst'),
     livereload.shell('make html'),
 )
 

--- a/src/releng_docs/services_shipit.rst
+++ b/src/releng_docs/services_shipit.rst
@@ -116,10 +116,16 @@ Initially we will integrate the legacy ship-it/release-runner infrastructure wit
 7. The pipeline service sees that S is finished, and creates step P via the Taskcluster service.
 
 
-Steps
------
+Step Services
+-------------
 
-Step Services API
+.. toctree::
+    :maxdepth: 1
+
+    shipit_signoffs/shipit-signoffs
+
+
+API
 ~~~~~~~~~~~~~~~~~
 
 In order to ensure the Pipeline service can successfully managed Steps, each Step Service is required to implement the following API:
@@ -146,15 +152,3 @@ In order to ensure the Pipeline service can successfully managed Steps, each Ste
   - Probably need to add support for including custom service-specific status info.
 
 Step Services are free to add additional endpoints past the required ones.
-
-
-``src/shipit_signoff``
-~~~~~~~~~~~~~~~~~~~~~~
-
-TODO
-
-
-``src/shipit_taskcluster``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-TODO

--- a/src/releng_docs/shipit_signoffs
+++ b/src/releng_docs/shipit_signoffs
@@ -1,0 +1,1 @@
+../shipit_signoff/docs

--- a/src/shipit_signoff/docs/shipit-signoffs.rst
+++ b/src/shipit_signoff/docs/shipit-signoffs.rst
@@ -1,0 +1,37 @@
+.. _shipit-signoffs:
+
+Signoffs Service
+========================
+
+Architecture
+------------
+
+.. graphviz::
+
+    digraph "Signoffs Architecture" {
+        "Signoffs Service" -> "Database";
+        "Signoffs Service" -> "Balrog Admin API";
+        "Signoffs Service" -> "Notifications Service";
+        "Pipeline Service" -> "Signoffs Service";
+        "Ship It UI" -> "Pipeline Service";
+        "Ship It UI" -> "Signoffs Service";
+        "User" -> "Ship It UI";
+        "User" -> "Auth0";
+        "User" -> "login.taskcluster.net";
+        "Auth0" -> "Signoffs Service";
+    }
+
+Signoff Policies
+----------------
+Over the wire and in memory, policies will be stored as lists of dictionaries. For example::
+
+    [
+        {
+            "users": ["userW", "userX"]
+        },
+        {
+            "groups": {"groupY": 2, "groupZ": 2}
+        }
+    ]
+
+Each item in the list represents a way of reaching quorum. In the example above, quorum is reached when either userW and userX sign off *or* when 2 people from groupY and 2 people from groupZ sign off.


### PR DESCRIPTION
Now that we've more or less settled on an architecture and policy format, we should add some docs. This could use a bit more fleshing out but it's a start.

@srfraser - could you review this from the Signoffs Service angle?
@garbas - I've incorporated the "put the docs with the app" ideas from #230 - came you let me know what you think about that?