### PR TITLE
bug 1354279 - update try syntax, for Gecko profiling

### DIFF
--- a/src/releng_frontend/src/static/trychooser/trychooser.js
+++ b/src/releng_frontend/src/static/trychooser/trychooser.js
@@ -209,7 +209,7 @@ $(document).ready(function() {
         });
 
         if ($('.profile').is(':checked')) {
-            args.push('mozharness: --spsProfile');
+            args.push('mozharness: --geckoProfile');
         }
 
         if ($('.no-retry').is(':checked')) {


### PR DESCRIPTION
This is a fix for [bug 1354279](https://bugzilla.mozilla.org/show_bug.cgi?id=1354279)

It's only a flag rename, required to mirror the [BE implementation](https://dxr.mozilla.org/mozilla-central/rev/ec8d1d3db50c85037e8077c32c8403570a5df493/testing/mozharness/mozharness/mozilla/testing/talos.py#175).