### PR TITLE
shipit_code_coverage: Update grcov and set some Coveralls metadata

### DIFF
--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -15,14 +15,14 @@ let
 
   # Marco grcov
   grcov = rustPlatform.buildRustPackage rec {
-    version = "0.1.9";
+    version = "0.1.11";
     name = "grcov-${version}";
 
     src = releng_pkgs.pkgs.fetchFromGitHub {
       owner = "marco-c";
       repo = "grcov";
       rev = "v${version}";
-      sha256 = "0m8fmihryj39rbbkfk26lbsy67jmfcm53p2lny10sjdq7b162p5i";
+      sha256 = "01qvyrzfvp0gq6flmpj2j6kpaiq345fhq6zin0wcs1ylfybwncr5";
     };
 
     # running 4 tests
@@ -46,7 +46,7 @@ let
     # error: test failed
     doCheck = false;
 
-    depsSha256 = "0h54gwhc7lgbxhkxk2z7z2gaxz5ivxikfsjwv3i2k2rh72y23hg1";
+    depsSha256 = "0lwkdmfwd4r9l5naxw1j3x5kglm9z0d03id8jkvgxn7awg3da8hm";
 
     meta = with releng_pkgs.pkgs.stdenv.lib; {
       description = "grcov collects and aggregates code coverage information for multiple source files.";

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 import requests
 import subprocess
 import hglib
@@ -69,6 +70,9 @@ def generate_info(revision, coveralls_token):
       '-t', 'coveralls',
       '-s', REPO_DIR,
       '-p', '/home/worker/workspace/build/src/',
+      '--service-name', 'TaskCluster',
+      '--service-number', datetime.today().strftime('%Y%m%d'),
+      '--service-job-number', '1',
       '--commit-sha', get_github_commit(revision),
       '--token', coveralls_token,
     ]


### PR DESCRIPTION
The latest version of `grcov` fixes a bug with a repository in a relative directory (like what we're using in this task) and exposes more options to set Coveralls metadata.

This PR is updating grcov and then making use of the additional parameters for setting Coveralls metadata.