### PR TITLE
Pulse listener task

### DIFF
--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -50,13 +50,44 @@ class TaskclusterClient(object):
 
         return tc_options
 
+    def get_secrets_service(self):
+        """
+        Configured Secrets Service
+        """
+        return taskcluster.Secrets(
+            self.build_options('secrets/v1')
+        )
+
+    def get_hooks_service(self):
+        """
+        Configured Hooks Service
+        """
+        return taskcluster.Hooks(
+            self.build_options('hooks/v1')
+        )
+
+    def get_queue_service(self):
+        """
+        Configured Queue Service
+        """
+        return taskcluster.Queue(
+            self.build_options('queue/v1')
+        )
+
+    def get_notify_service(self):
+        """
+        Configured Queue Service
+        """
+        return taskcluster.Notify(
+            self.build_options('notify/v1')
+        )
+
     def get_secrets(self, path, required=[]):
         """
         Get secrets from a specific path
         and check mandatory ones
         """
-        options = self.build_options('secrets/v1')
-        secrets = taskcluster.Secrets(options).get(path)
+        secrets = self.get_secrets_service().get(path)
         secrets = secrets['secret']
         for req in required:
             if req not in secrets:
@@ -68,9 +99,7 @@ class TaskclusterClient(object):
         """
         Send an email through Taskcluster notification service
         """
-        options = self.build_options('notify/v1')
-        notify = taskcluster.Notify(options)
-        return notify.email({
+        return self.get_notify_service().email({
             'address': address,
             'subject': subject,
             'content': content,

--- a/src/shipit_pulse_listener/requirements.nix
+++ b/src/shipit_pulse_listener/requirements.nix
@@ -237,7 +237,6 @@ let
       self."Logbook"
       self."aioamqp"
       self."click"
-      self."python-hglib"
       self."structlog"
       self."taskcluster"
     ];
@@ -355,21 +354,6 @@ let
         homepage = "";
         license = licenses.mit;
         description = "pytest: simple powerful testing with Python";
-      };
-    };
-
-
-
-    "python-hglib" = python.mkDerivation {
-      name = "python-hglib-2.4";
-      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/3a/6c/52c4ba6050b80e266d87783ccd4d39b76a0d2459965abf1c7bde54dd9a72/python-hglib-2.4.tar.gz"; sha256 = "693d6ed92a6566e78802c7a03c256cda33d08c63ad3f00fcfa11379b184b9462"; };
-      doCheck = commonDoCheck;
-      buildInputs = commonBuildInputs;
-      propagatedBuildInputs = [ ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "";
-        license = licenses.mit;
-        description = "Mercurial Python library";
       };
     };
 

--- a/src/shipit_pulse_listener/requirements.txt
+++ b/src/shipit_pulse_listener/requirements.txt
@@ -1,1 +1,1 @@
--e ./../../lib/cli_common[pulse,taskcluster,mercurial]#egg=mozilla-cli-common
+-e ./../../lib/cli_common[pulse,taskcluster]#egg=mozilla-cli-common

--- a/src/shipit_pulse_listener/requirements_frozen.txt
+++ b/src/shipit_pulse_listener/requirements_frozen.txt
@@ -16,7 +16,6 @@ pycodestyle==2.3.1
 pyflakes==1.5.0
 pyparsing==2.2.0
 pytest==3.0.7
-python-hglib==2.4
 requests==2.13.0
 six==1.10.0
 slugid==1.0.7

--- a/src/shipit_pulse_listener/shipit_pulse_listener/__init__.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/__init__.py
@@ -1,0 +1,5 @@
+from cli_common.log import init_logger
+
+
+# Setup logger for bot execution
+init_logger()

--- a/src/shipit_pulse_listener/shipit_pulse_listener/cli.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/cli.py
@@ -1,12 +1,18 @@
 import click
+from shipit_pulse_listener.listener import PulseListener
 
 
 @click.command()
+@click.argument('hooks', nargs=-1)
 @click.option('--secrets', required=True, help='Taskcluster Secrets path')
 @click.option('--client-id', help='Taskcluster Client ID')
 @click.option('--client-token', help='Taskcluster Client token')
-def main(secrets, client_id, client_token):
-    pass
+def main(hooks, secrets, client_id, client_token):
+    if not hooks:
+        raise Exception('Specify at least one hook (hookGroupId:hookId)')
+
+    pl = PulseListener(secrets, client_id, client_token)
+    pl.run(hooks)
 
 
 if __name__ == '__main__':

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -95,14 +95,14 @@ class PulseListener(object):
         # Ack the message so it is removed from the broker's queue
         await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
-    def run_task(self, task_payload, ttl=5, extra_env={}):
+    def run_task(self, task_definition, ttl=5, extra_env={}):
         """
         Create a new task on Taskcluster
         """
-        assert isinstance(task_payload, dict)
+        assert isinstance(task_definition, dict)
 
         # Update the env in task
-        task_payload['payload']['env'].update(extra_env)
+        task_definition['payload']['env'].update(extra_env)
 
         # Get taskcluster queue
         queue = self.taskcluster.get_queue_service()
@@ -112,9 +112,9 @@ class PulseListener(object):
 
         # Set dates
         now = datetime.utcnow()
-        task_payload['created'] = now
-        task_payload['deadline'] = now + timedelta(seconds=ttl * 3600)
-        logger.info('Creating a new task', id=task_id, name=task_payload['metadata']['name'])  # noqa
+        task_definition['created'] = now
+        task_definition['deadline'] = now + timedelta(seconds=ttl * 3600)
+        logger.info('Creating a new task', id=task_id, name=task_definition['metadata']['name'])  # noqa
 
         # Create a new task
-        return queue.createTask(task_id, task_payload)
+        return queue.createTask(task_id, task_definition)

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timedelta
+from taskcluster.utils import slugId
+from cli_common.pulse import create_consumer, run_consumer
+from cli_common.taskcluster import TaskclusterClient
+from cli_common.log import get_logger
+import copy
+import json
+import re
+
+logger = get_logger(__name__)
+
+HOOK_REGEX = re.compile(r'([\w\-_]+):([\w\-_]+)')
+
+
+class PulseListener(object):
+    """
+    Listen to pulse messages and trigger new tasks
+    """
+    def __init__(self, secrets_path, client_id=None, access_token=None):
+        self.taskcluster = TaskclusterClient(client_id, access_token)
+        self.tasks = []
+
+        # Fetch pulse credentials from TC secrets
+        logger.info('Using secrets', path=secrets_path)
+        required = ('PULSE_USER', 'PULSE_PASSWORD', 'PULSE_QUEUE')
+        secrets = self.taskcluster.get_secrets(secrets_path, required)
+
+        # Use pulse consumer from bot_common
+        self.consumer = create_consumer(
+            secrets['PULSE_USER'],
+            secrets['PULSE_PASSWORD'],
+            secrets['PULSE_QUEUE'],
+            secrets.get('PULSE_TOPIC', '#'),
+            self.got_message
+        )
+
+    def load_hooks(self, hooks):
+        """
+        Load task payloads from hooks definitiions
+        """
+        assert len(hooks) > 0, \
+            'Missing hooks definitions'
+
+        service = self.taskcluster.get_hooks_service()
+        for hook in hooks:
+
+            # Get hook definitions
+            result = HOOK_REGEX.search(hook)
+            if result is None:
+                logger.warn('Invalid hook definition', definition=hook)
+                continue
+
+            hookGroupId, hookId = result.groups()
+            logger.info('Using hook definition', group=hookGroupId, id=hookId)
+
+            # Get task payload from hook
+            hook_payload = service.hook(hookGroupId, hookId)
+            self.tasks.append(hook_payload['task'])
+
+        if not self.tasks:
+            raise Exception('No tasks to run.')
+
+    def run(self, hooks):
+
+        # Load hook group/id combos
+        self.load_hooks(hooks)
+
+        # Run forever consumer below
+        logger.info('Listening for new messages...')
+        run_consumer(self.consumer)
+
+    async def got_message(self, channel, body, envelope, properties):
+        """
+        Pulse consumer callback
+        """
+        assert isinstance(body, bytes), \
+            'Body is not in bytes'
+
+        # Extract bugzilla id from body
+        body = json.loads(body.decode('utf-8'))
+        if 'payload' not in body:
+            raise Exception('Missing payload in body')
+        bugzilla_id = body['payload'].get('id')
+        if not bugzilla_id:
+            raise Exception('Missing bugzilla id')
+        logger.info('Received new Bugzilla message', bz_id=bugzilla_id)
+
+        # Start new tasks for every bugzilla id
+        env = {
+            'BUGZILLA_ID': bugzilla_id,
+        }
+        for task in self.tasks:
+            self.run_task(copy.deepcopy(task), extra_env=env)
+
+        # Ack the message so it is removed from the broker's queue
+        await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
+
+    def run_task(self, task_payload, ttl=5, extra_env={}):
+        """
+        Create a new task on Taskcluster
+        """
+        assert isinstance(task_payload, dict)
+
+        # Update the env in task
+        task_payload['payload']['env'].update(extra_env)
+
+        # Get taskcluster queue
+        queue = self.taskcluster.get_queue_service()
+
+        # Build task id
+        task_id = slugId().decode('utf-8')
+
+        # Set dates
+        now = datetime.utcnow()
+        task_payload['created'] = now
+        task_payload['deadline'] = now + timedelta(seconds=ttl * 3600)
+        logger.info('Creating a new task', id=task_id, name=task_payload['metadata']['name'])  # noqa
+
+        # Create a new task
+        return queue.createTask(task_id, task_payload)


### PR DESCRIPTION
Static analysis and risk assessment tasks must be triggered by some pulse messages.

As Taskcluster does not yet support this behavior, a reccurent task needs to listen to pulse message and triggers tasks.

As Taskcluster does not yet support to modify the environment or command from a hook, we need to read the hook definition, and use the task payload to create a new task.