### PR TITLE
Bug 1352333 - Autophone - fix bad trychooser value for autophone-cras…

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -410,7 +410,7 @@
             <li><label><input type="checkbox" value="autophone-crashtest-dom-media">autophone-crashtest-dom-media (Cdm1)</label></li>
             <li><label><input type="checkbox" value="autophone-crashtest-dom-media-tests">autophone-crashtest-dom-media-tests (Cdm2)</label></li>
             <li><label><input type="checkbox" value="autophone-crashtest-dom-media-mediasource">autophone-crashtest-dom-media-mediasource (Cdm3)</label></li>
-            <li><label><input type="checkbox" value="autophone-crashtest-dom-media-tests">autophone-crashtest-media-webspeech-synth (Cdm4)</label></li>
+            <li><label><input type="checkbox" value="autophone-crashtest-dom-media-webspeech-synth">autophone-crashtest-dom-media-webspeech-synth (Cdm4)</label></li>
             <li><label><input type="checkbox" value="autophone-mochitest-dom-browser-element">autophone-mochitest-dom-browser-element (Mdb)</label></li>
             <li><label><input type="checkbox" value="autophone-mochitest-dom-media">autophone-mochitest-dom-media (Mdm1)</label></li>
             <li><label><input type="checkbox" value="autophone-mochitest-dom-media-tests">autophone-mochitest-dom-media-tests (Mdm2)</label></li>


### PR DESCRIPTION
…htest-dom-media-webspeech-synth

I messed up the value and description for autophone-crashtest-dom-media-webspeech-synth in the previous pull request. This resulted in Cdm4 not being invoked using the try syntax produced by trychooser. I did a new test with this change and all tests were properly started using the produced try message:

https://treeherder.mozilla.org/#/jobs?repo=try&revision=88022e5d1b3a3e29ea1896b0f175b09b2c869a28&exclusion_profile=false
