### PR TITLE
Removed windows clang builds, which don't appear to work

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -106,11 +106,6 @@
                 <span id="build_win32" class="build_queue">N/A</span>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="win32-clang">win32-clang</label>
-                <span id="test_win32-clang" class="test_queue">N/A</span>
-                <span id="build_win32-clang" class="build_queue">N/A</span>
-            </li>
-            <li>
                 <label><input type="checkbox" name="platform" value="win32-st-an">win32 static analysis</label>
                 <span id="test_win32-st-an" class="test_queue">N/A</span>
                 <span id="build_win32-st-an" class="build_queue">N/A</span>
@@ -119,11 +114,6 @@
                 <label><input type="checkbox" name="platform" value="win64">win64</label>
                 <span id="test_win64" class="test_queue">N/A</span>
                 <span id="build_win64" class="build_queue">N/A</span>
-            </li>
-            <li>
-                <label><input type="checkbox" name="platform" value="win64-clang">win64-clang</label>
-                <span id="test_win64-clang" class="test_queue">N/A</span>
-                <span id="build_win64-clang" class="build_queue">N/A</span>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="win64-st-an">win64 static analysis</label>


### PR DESCRIPTION
Example failure: https://treeherder.mozilla.org/logviewer.html#?job_id=93804902&repo=try&lineNumber=662

cc: @garbas 