### PR TITLE
flake8: Change max line length to 159

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -528,7 +528,7 @@ in rec {
               export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
               export APP_TESTING=${name}
 
-              flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
+              flake8
               pytest tests/
             '';
 
@@ -609,6 +609,8 @@ in rec {
 
         patchPhase = ''
           # replace synlink with real file
+          rm -f setup.cfg
+          ln -s ${../setup.cfg} setup.cfg
 
           # generate MANIFEST.in to make sure every file is included
           rm -f MANIFEST.in
@@ -634,7 +636,7 @@ in rec {
               export LANG=en_US.UTF-8
               export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
 
-              flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
+              flake8
               pytest tests/
             '';
 

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -528,7 +528,7 @@ in rec {
               export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
               export APP_TESTING=${name}
 
-              flake8 --exclude=nix_run_setup.py,migrations/,build/
+              flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
               pytest tests/
             '';
 
@@ -634,7 +634,7 @@ in rec {
               export LANG=en_US.UTF-8
               export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
 
-              flake8 --exclude=nix_run_setup.py,migrations/,build/
+              flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
               pytest tests/
             '';
 

--- a/nix/requirements_override.nix
+++ b/nix/requirements_override.nix
@@ -35,7 +35,7 @@ in skipOverrides {
       rm -rf build *.egg-info
     '';
     checkPhase = ''
-      flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
+      flake8
       pytest tests
     '';
   };
@@ -51,7 +51,7 @@ in skipOverrides {
     '';
     # TODO: doCheck = true;
     checkPhase = ''
-      flake8 --exclude=nix_run_setup.py,build/ --max-line-length=159
+      flake8
       pytest tests
     '';
   };

--- a/nix/requirements_override.nix
+++ b/nix/requirements_override.nix
@@ -35,7 +35,7 @@ in skipOverrides {
       rm -rf build *.egg-info
     '';
     checkPhase = ''
-      flake8 --exclude=nix_run_setup.py,migrations/,build/
+      flake8 --exclude=nix_run_setup.py,migrations/,build/ --max-line-length=159
       pytest tests
     '';
   };
@@ -51,7 +51,7 @@ in skipOverrides {
     '';
     # TODO: doCheck = true;
     checkPhase = ''
-      flake8 --exclude=nix_run_setup.py,build/
+      flake8 --exclude=nix_run_setup.py,build/ --max-line-length=159
       pytest tests
     '';
   };

--- a/nix/setup.cfg
+++ b/nix/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 159
+exclude=nix_run_setup.py,migrations/,build/

--- a/src/releng_archiver/setup.cfg
+++ b/src/releng_archiver/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/releng_clobberer/setup.cfg
+++ b/src/releng_clobberer/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/releng_docs/setup.cfg
+++ b/src/releng_docs/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/releng_mapper/setup.cfg
+++ b/src/releng_mapper/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/releng_tooltool/setup.cfg
+++ b/src/releng_tooltool/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/releng_treestatus/setup.cfg
+++ b/src/releng_treestatus/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_bot_uplift/setup.cfg
+++ b/src/shipit_bot_uplift/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_code_coverage/setup.cfg
+++ b/src/shipit_code_coverage/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_pipeline/.flake8
+++ b/src/shipit_pipeline/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120

--- a/src/shipit_pipeline/setup.cfg
+++ b/src/shipit_pipeline/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_pulse_listener/setup.cfg
+++ b/src/shipit_pulse_listener/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_risk_assessment/setup.cfg
+++ b/src/shipit_risk_assessment/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_signoff/default.nix
+++ b/src/shipit_signoff/default.nix
@@ -16,14 +16,6 @@ let
     inherit python name dirname;
     version = fileContents ./VERSION;
     src = filterSource ./. { inherit name; };
-    checkPhase = ''
-      export LANG=en_US.UTF-8
-      export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
-      export APP_TESTING=${name}
-
-      flake8 --exclude=nix_run_setup.py,migrations/,build/
-      pytest tests/
-    '';
     buildInputs =
       fromRequirementsFile ./requirements-dev.txt python.packages;
     propagatedBuildInputs =

--- a/src/shipit_signoff/setup.cfg
+++ b/src/shipit_signoff/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_static_analysis/setup.cfg
+++ b/src/shipit_static_analysis/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_taskcluster/setup.cfg
+++ b/src/shipit_taskcluster/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg

--- a/src/shipit_uplift/setup.cfg
+++ b/src/shipit_uplift/setup.cfg
@@ -1,0 +1,1 @@
+../../nix/setup.cfg


### PR DESCRIPTION
Following up on the last IRC comments, we may want to be consistent with the other projects in release engineering. The following projects use either 159 or 160 characters:
* https://dxr.mozilla.org/build-central/rev/f16d6d84ce68be7a4cf1ee8d0b58d3ebf6b87522/buildbot-configs/tox.ini#51
* https://dxr.mozilla.org/build-central/rev/81124f4c497759ef11d96448b9bd1ab063164e9d/tools/tox.ini#43
* https://dxr.mozilla.org/build-central/rev/f608764128705acea53ff8c6a42482f09038c6b2/cloud-tools/tox.ini#26
* https://github.com/mozilla-releng/funsize/blob/6c78431780545ee8d82529ab324489d2ae266933/tox.ini#L25
* https://github.com/mozilla-releng/scriptworker/blob/e244cd34fe9fbf34dc7d244014217057fcc4b2d7/tox.ini#L41
* https://github.com/mozilla-releng/beetmoverscript/blob/1f043f2c0cba10e7b5668404aac9b6194786ceb1/tox.ini#L40
* https://github.com/mozilla-releng/signtool/blob/ace96a9e8ace4fd79386c0aa273b5967d4238cfb/tox.ini#L43

What do you think @garbas ? 