### PR TITLE
Remove the dead platforms android-api-15-frontend, sm-warnaserr, and …

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -141,11 +141,6 @@
                 <span id="build_android-api-15-gradle" class="build_queue">N/A</span>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="android-api-15-frontend">android api 15+ frontend</label>
-                <span id="test_android-api-15-frontend" class="test_queue">N/A</span>
-                <span id="build_android-api-15-frontend" class="build_queue">N/A</span>
-            </li>
-            <li>
                 <label><input type="checkbox" name="platform" value="android-x86">android-x86 (Android 4.2)</label>
                 <span id="test_android-x86" class="test_queue">N/A</span>
                 <span id="build_android-x86" class="build_queue">N/A</span>
@@ -168,11 +163,6 @@
                 <span id="build_sm-compacting" class="build_queue">N/A</span>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="sm-generational">Spidermonkey generational</label>
-                <span id="test_sm-generational" class="test_queue">N/A</span>
-                <span id="build_sm-generational" class="build_queue">N/A</span>
-            </li>
-            <li>
                 <label><input type="checkbox" name="platform" value="sm-plain">Spidermonkey plain</label>
                 <span id="test_sm-plain" class="test_queue">N/A</span>
                 <span id="build_sm-plain" class="build_queue">N/A</span>
@@ -181,11 +171,6 @@
                 <label><input type="checkbox" name="platform" value="sm-rootanalysis">Spidermonkey rootanalysis</label>
                 <span id="test_sm-rootanalysis" class="test_queue">N/A</span>
                 <span id="build_sm-rootanalysis" class="build_queue">N/A</span>
-            </li>
-            <li>
-                <label><input type="checkbox" name="platform" value="sm-warnaserr">Spidermonkey warnaserr</label>
-                <span id="test_sm-warnaserr" class="test_queue">N/A</span>
-                <span id="build_sm-warnaserr" class="build_queue">N/A</span>
             </li>
             </ul>
             <p>Looking for PGO builds? See <a href="https://wiki.mozilla.org/ReleaseEngineering/TryChooser#What_if_I_want_PGO_for_my_build">this page</a>.</p>


### PR DESCRIPTION
…sm-generational from trychooser

android-api-15-frontend was renamed to android-test [a year ago](https://bugzilla.mozilla.org/show_bug.cgi?id=1260874), and the fact that nobody has made even the tiniest peep about not knowing how to trigger it is a sign it's not needed; if someone wants to run it, they can add it with whatever name it has then (and I hope that name is better than A Build Named Test).

sm-generational was removed [a year ago](https://bugzilla.mozilla.org/show_bug.cgi?id=1272720), a year after [forgetting that it was only left around](https://bugzilla.mozilla.org/show_bug.cgi?id=1136309) for the period between landing an in-tree patch and a buildbot patch.

Bug archaeology of the death of sm-warnaserr is... not recommended. There are things like a three-year period when we had two different configure args for enabling warnings-as-errors, both of which actually disabled warnings-as-errors. It doesn't exist, attempting to run it now causes the taskcluster decision-task to fail, that's enough, it should be gone.