### PR TITLE
Replace mochitest-o with mochitest-a11y and mochitest-chrome

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -302,7 +302,8 @@
                     </li>
                     <li><label><input type="checkbox" value="mochitest-clipboard">mochitest-clipboard</label></li>
                     <li><label><input type="checkbox" value="mochitest-dt">mochitest-dt (devtools)</label></li>
-                    <li><label><input type="checkbox" value="mochitest-o">mochitest-o (other)</label></li>
+                    <li><label><input type="checkbox" value="mochitest-a11y">mochitest-ally</label></li>
+                    <li><label><input type="checkbox" value="mochitest-chrome">mochitest-chrome</label></li>
                     <li><label><input type="checkbox" value="mochitest-media">mochitest-mda (dom/media)</label></li>
                     <li><label><input type="checkbox" value="mochitest-jetpack">mochitest-jetpack</label></li>
                     <li><label><input type="checkbox" value="mochitest-e10s-1">mochitest-e10s-1</label></li>


### PR DESCRIPTION
Over the course of a year, we slowly platform-by-platform replaced the mochitest-other suite with separate suites of the things it ran, mochitest-a11y and mochitest-chrome, without ever bothering to update trychooser. Now we've split it up on every platform, and mochitest-o/mochitest-other no longer exists, still without ever bothering to update trychooser.

Having this actually work on every platform depends on a patch for [bug 1357701](https://bugzilla.mozilla.org/show_bug.cgi?id=1357701#c2), but that doesn't actually block this landing, since mochitest-o no longer exists, mochitest-a11y works, and mochitest-chrome works on Linux and Android (and Mac debug, though it working there is only because of yet another bug). 

Having these in there is better than the current state, and having a stew of mochitest-chrome-n (we run three chunks on desktop, two on Android opt, and four on Android debug, so even if we were going to list them all separately, a bad idea since it implies their contents are fixed, I can't describe how we would do it; 3 in the main section, and just -4 in the Android section? 3 in the main and all 4 in the Android? 3 in the main, 2 in an new Android opt section and 4 in a new Android debug section?).