### PR TITLE
Fix inaccurate info in reftest/crashtest labels, give up on chunks

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -257,15 +257,11 @@
             <label><input type="checkbox" class="group-selector all-selector">All</label>
             <label><input type="checkbox" class="group-selector none-selector" CHECKED>None</label>
             <ul>
-                <li><label><input type="checkbox" value="reftest">reftest</label></li>
-                <li><label><input type="checkbox" value="reftest-1">reftest-1<span class="info">(linux only)</span></label></li>
-                <li><label><input type="checkbox" value="reftest-2">reftest-2<span class="info">(linux only)</span></label></li>
-                <li><label><input type="checkbox" value="reftest-3">reftest-3<span class="info">(linux debug only)</span></label></li>
-                <li><label><input type="checkbox" value="reftest-4">reftest-4<span class="info">(linux debug only)</span></label></li>
-                <li><label><input type="checkbox" value="reftest-e10s">reftest-e10s <span class="info">(linux/win7 only)</span></label></li>
+                <li><label><input type="checkbox" value="reftest">reftest <span class="info">(includes e10s and no-accel)</span></label></li>
+                <li><label><input type="checkbox" value="reftest-e10s">reftest-e10s</span></label></li>
                 <li><label><input type="checkbox" value="reftest-no-accel">reftest-no-accel <span class="info">(linux/win7/8 only)</span></label></li>
                 <li><label><input type="checkbox" value="crashtest">crashtest</label></li>
-                <li><label><input type="checkbox" value="crashtest-e10s">crashtest-e10s <span class="info">(linux/win7 only)</span></label></li>
+                <li><label><input type="checkbox" value="crashtest-e10s">crashtest-e10s</span></label></li>
                 <li><label><input type="checkbox" value="xpcshell">xpcshell</label></li>
                 <li><label><input type="checkbox" value="jsreftest">jsreftest</label></li>
                 <li><label><input type="checkbox" value="marionette">marionette</label></li>


### PR DESCRIPTION
If there's one thing that's true about trychooser/try syntax, it's that there's no one true thing about it.

Despite the fact that I'll shortly have a PR that adds more individual chunks for mochitests, it doesn't make sense to maintain a list of chunks for reftests: they run in a bewildering variety of chunks (8 on Linux, 1 on Mac and Windows opt, 2 on Windows debug, and only the 2 e10s on Mac debug, and insane 16 and 48 chunks on Android, which I'm not yet prepared to touch), and unlike mochitests where it might be reasonable to run only M10 because you're working on toolkit/components/alerts/ on Linux64 and don't need to run totally unrelated browser/components/feeds/ tests in M1, with reftests you're generally working on... layout stuff, and you need to run the reftest chunks that deal with layout stuff, which is all of them, all the more so because on Mac you have no choice but to run them all, and on Windows no choice but to run at least half of them. Even if we did list reftest-1 through reftest-10, there would be absolutely no sane way to label them, since accurate labels would be things like "reftest-1 (linux and windows only, but totally utterly different things on linux and on windows and for mac you have to pick just 'reftest' anyway because reftest-1 doesn't run reftest when there's only one, so why are you here at all?)"

Removing the info span on crashtest-e10s is just a driveby, we long since started running it on Mac and Win8.

