### PR TITLE
Add mochitest chunks 6-10

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -293,6 +293,11 @@
                     <li><label><input type="checkbox" value="mochitest-3">mochitest-3</label></li>
                     <li><label><input type="checkbox" value="mochitest-4">mochitest-4</label></li>
                     <li><label><input type="checkbox" value="mochitest-5">mochitest-5</label></li>
+                    <li><label><input type="checkbox" value="mochitest-6">mochitest-6</label></li>
+                    <li><label><input type="checkbox" value="mochitest-7">mochitest-7</label></li>
+                    <li><label><input type="checkbox" value="mochitest-8">mochitest-8</label></li>
+                    <li><label><input type="checkbox" value="mochitest-9">mochitest-9</label></li>
+                    <li><label><input type="checkbox" value="mochitest-10">mochitest-10</label></li>
                     <li><label><input type="checkbox" value="mochitest-gl">mochitest-gl (webgl)</label></li>
                     <li><label><input type="checkbox" value="mochitest-bc">mochitest-bc (browser chrome)</label></li>
                     <li>


### PR DESCRIPTION
As I rambled on about [separately](https://github.com/mozilla-releng/services/pull/287) for reftests, selecting chunks in trychooser isn't great, but for mochitests it's a simpler "there's 10 chunks on Linux, 5 on Mac and Windows" and [bug 1359213](https://bugzilla.mozilla.org/show_bug.cgi?id=1359213) says there's demand for selecting individual chunks beyond 5.