### PR TITLE
shipit_code_coverage: Cache mozilla-central repository

### DIFF
--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -58,6 +58,7 @@ let
 
   mkBot = branch:
     let
+      cacheKey = "shipit-static-analysis-" + branch;
       secretsKey = "repo:github.com/mozilla-releng/services:branch:" + branch;
     in
       mkTaskclusterHook {
@@ -68,7 +69,13 @@ let
         scopes = [
           # Used by taskclusterProxy
           ("secrets:get:" + secretsKey)
+
+          # Used by cache
+          ("docker-worker:cache:" + cacheKey)
         ];
+        cache = {
+          "${cacheKey}" = "/cache";
+        };
         taskEnv = {
           "SSL_CERT_FILE" = "${releng_pkgs.pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
         };
@@ -76,6 +83,8 @@ let
           "/bin/shipit-code-coverage"
           "--secrets"
           secretsKey
+          "--cache-root"
+          "/cache"
         ];
         deadline = "5 hours";
         maxRunTime = 18000;

--- a/src/shipit_code_coverage/shipit_code_coverage/cli.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/cli.py
@@ -1,14 +1,20 @@
 import click
 
-from shipit_code_coverage import codecov
+from shipit_code_coverage.codecov import CodeCov
 
 
 @click.command()
+@click.option(
+    '--cache-root',
+    required=True,
+    help='Cache root, used to pull changesets'
+)
 @click.option('--secrets', required=True, help='Taskcluster Secrets path')
 @click.option('--client-id', help='Taskcluster Client ID')
 @click.option('--client-token', help='Taskcluster Client token')
-def main(secrets, client_id, client_token):
-    codecov.go(secrets, client_id, client_token)
+def main(cache_root, secrets, client_id, client_token):
+    c = CodeCov(cache_root, secrets, client_id, client_token)
+    c.go()
 
 
 if __name__ == '__main__':

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -14,153 +14,149 @@ from shipit_code_coverage import coverage_by_dir
 
 logger = get_logger(__name__)
 
-REPO_CENTRAL = 'https://hg.mozilla.org/mozilla-central'
-REPO_DIR = 'mozilla-central'
 COVERALLS_TOKEN_FIELD = 'SHIPIT_CODE_COVERAGE_COVERALLS_TOKEN'
 CODECOV_TOKEN_FIELD = 'SHIPIT_CODE_COVERAGE_CODECOV_TOKEN'
 
 
-def is_coverage_task(task):
-    return task['task']['metadata']['name'].startswith('test-linux64-ccov')
+class CodeCov(object):
+    def is_coverage_task(self, task):
+        return task['task']['metadata']['name'].startswith('test-linux64-ccov')
 
+    def download_coverage_artifacts(self, build_task_id):
+        try:
+            os.mkdir('ccov-artifacts')
+        except:
+            pass
 
-def download_coverage_artifacts(build_task_id):
-    try:
-        os.mkdir('ccov-artifacts')
-    except:
-        pass
+        task_data = taskcluster.get_task_details(build_task_id)
 
-    task_data = taskcluster.get_task_details(build_task_id)
-
-    artifacts = taskcluster.get_task_artifacts(build_task_id)
-    for artifact in artifacts:
-        if 'target.code-coverage-gcno.zip' in artifact['name']:
-            taskcluster.download_artifact(build_task_id, artifact)
-
-    tasks = taskcluster.get_tasks_in_group(task_data['taskGroupId'])
-    test_tasks = [t for t in tasks if is_coverage_task(t)]
-    for test_task in test_tasks:
-        test_task_id = test_task['status']['taskId']
-        artifacts = taskcluster.get_task_artifacts(test_task_id)
+        artifacts = taskcluster.get_task_artifacts(build_task_id)
         for artifact in artifacts:
-            if 'code-coverage-gcda.zip' in artifact['name']:
-                taskcluster.download_artifact(test_task_id, artifact)
+            if 'target.code-coverage-gcno.zip' in artifact['name']:
+                taskcluster.download_artifact(build_task_id, artifact)
 
+        tasks = taskcluster.get_tasks_in_group(task_data['taskGroupId'])
+        test_tasks = [t for t in tasks if self.is_coverage_task(t)]
+        for test_task in test_tasks:
+            test_task_id = test_task['status']['taskId']
+            artifacts = taskcluster.get_task_artifacts(test_task_id)
+            for artifact in artifacts:
+                if 'code-coverage-gcda.zip' in artifact['name']:
+                    taskcluster.download_artifact(test_task_id, artifact)
 
-def get_github_commit(mercurial_commit):
-    url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s'
-    r = requests.get(url % mercurial_commit)
+    def get_github_commit(self, mercurial_commit):
+        url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s'
+        r = requests.get(url % mercurial_commit)
 
-    return r.text.split(' ')[0]
+        return r.text.split(' ')[0]
 
+    def generate_info(self, commit_sha, coveralls_token):
+        files = os.listdir('ccov-artifacts')
+        ordered_files = []
+        for fname in files:
+            if not fname.endswith('.zip'):
+                continue
 
-def generate_info(commit_sha, coveralls_token):
-    files = os.listdir('ccov-artifacts')
-    ordered_files = []
-    for fname in files:
-        if not fname.endswith('.zip'):
-            continue
+            if 'gcno' in fname:
+                ordered_files.insert(0, 'ccov-artifacts/' + fname)
+            else:
+                ordered_files.append('ccov-artifacts/' + fname)
 
-        if 'gcno' in fname:
-            ordered_files.insert(0, 'ccov-artifacts/' + fname)
-        else:
-            ordered_files.append('ccov-artifacts/' + fname)
+        cmd = [
+          'grcov',
+          '-z',
+          '-t', 'coveralls',
+          '-s', self.repo_dir,
+          '-p', '/home/worker/workspace/build/src/',
+          '--ignore-dir', 'gcc',
+          '--ignore-not-existing',
+          '--service-name', 'TaskCluster',
+          '--service-number', datetime.today().strftime('%Y%m%d'),
+          '--service-job-number', '1',
+          '--commit-sha', commit_sha,
+          '--token', coveralls_token,
+        ]
+        cmd.extend(ordered_files)
 
-    cmd = [
-      'grcov',
-      '-z',
-      '-t', 'coveralls',
-      '-s', REPO_DIR,
-      '-p', '/home/worker/workspace/build/src/',
-      '--ignore-dir', 'gcc',
-      '--ignore-not-existing',
-      '--service-name', 'TaskCluster',
-      '--service-number', datetime.today().strftime('%Y%m%d'),
-      '--service-job-number', '1',
-      '--commit-sha', commit_sha,
-      '--token', coveralls_token,
-    ]
-    cmd.extend(ordered_files)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (output, err) = p.communicate()
 
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (output, err) = p.communicate()
+        if p.returncode != 0:
+            raise Exception('Error while running grcov:\n' + err.decode('utf-8'))
 
-    if p.returncode != 0:
-        raise Exception('Error while running grcov:\n' + err.decode('utf-8'))
+        return output
 
-    return output
+    def clone_mozilla_central(self, revision):
+        shared_dir = self.repo_dir + '-shared'
+        cmd = hglib.util.cmdbuilder('robustcheckout',
+                                    'https://hg.mozilla.org/mozilla-central',
+                                    self.repo_dir,
+                                    purge=True,
+                                    sharebase=shared_dir,
+                                    branch=b'tip')
 
+        cmd.insert(0, hglib.HGPATH)
+        proc = hglib.util.popen(cmd)
+        out, err = proc.communicate()
+        if proc.returncode:
+            raise hglib.error.CommandError(cmd, proc.returncode, out, err)
 
-def clone_mozilla_central(revision):
-    shared_dir = REPO_DIR + '-shared'
-    cmd = hglib.util.cmdbuilder('robustcheckout',
-                                REPO_CENTRAL,
-                                REPO_DIR,
-                                purge=True,
-                                sharebase=shared_dir,
-                                branch=b'tip')
+        hg = hglib.open(self.repo_dir)
 
-    cmd.insert(0, hglib.HGPATH)
-    proc = hglib.util.popen(cmd)
-    out, err = proc.communicate()
-    if proc.returncode:
-        raise hglib.error.CommandError(cmd, proc.returncode, out, err)
+        hg.update(rev=revision, clean=True)
 
-    hg = hglib.open(REPO_DIR)
+    def run_command(self, cmd):
+        """
+        Run a command in the repo through subprocess
+        """
+        # Use gecko-env to run command
+        cmd = ['gecko-env', ] + cmd
 
-    hg.update(rev=revision, clean=True)
+        # Run command with env
+        logger.info('Running repo command', cmd=' '.join(cmd))
+        proc = subprocess.Popen(cmd, cwd=self.repo_dir)
+        exit = proc.wait()
 
+        if exit != 0:
+            raise Exception('Invalid exit code for command {}: {}'.format(cmd, exit))  # NOQA
 
-def run_command(cmd):
-    """
-    Run a command in the repo through subprocess
-    """
-    # Use gecko-env to run command
-    cmd = ['gecko-env', ] + cmd
+    def build_files(self):
+        with open(os.path.join(self.repo_dir, '.mozconfig'), 'w') as f:
+            f.write('mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-firefox')
 
-    # Run command with env
-    logger.info('Running repo command', cmd=' '.join(cmd))
-    proc = subprocess.Popen(cmd, cwd=REPO_DIR)
-    exit = proc.wait()
+        self.run_command(['./mach', 'configure'])
+        self.run_command(['./mach', 'build', 'pre-export'])
+        self.run_command(['./mach', 'build', 'export'])
 
-    if exit != 0:
-        raise Exception('Invalid exit code for command {}: {}'.format(cmd, exit))  # NOQA
+    def go(self):
+        task_id = taskcluster.get_last_task()
 
+        task_data = taskcluster.get_task_details(task_id)
+        revision = task_data['payload']['env']['GECKO_HEAD_REV']
+        logger.info('Revision %s' % revision)
+        commit_sha = self.get_github_commit(revision)
+        logger.info('GitHub revision %s' % commit_sha)
 
-def build_files():
-    with open(os.path.join(REPO_DIR, '.mozconfig'), 'w') as f:
-        f.write('mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-firefox')
+        self.download_coverage_artifacts(task_id)
 
-    run_command(['./mach', 'configure'])
-    run_command(['./mach', 'build', 'pre-export'])
-    run_command(['./mach', 'build', 'export'])
+        self.clone_mozilla_central(revision)
+        self.build_files()
 
+        output = self.generate_info(commit_sha, self.coveralls_token)
 
-def go(secrets, client_id=None, client_token=None):
-    tc_client = TaskclusterClient(client_id, client_token)
+        uploader.coveralls(output)
+        uploader.codecov(output, commit_sha, self.codecov_token)
 
-    required_fields = [COVERALLS_TOKEN_FIELD, CODECOV_TOKEN_FIELD]
-    secrets = tc_client.get_secrets(secrets, required_fields)
+        coverage_by_dir.generate(self.repo_dir)
 
-    coveralls_token = secrets[COVERALLS_TOKEN_FIELD]
-    codecov_token = secrets[CODECOV_TOKEN_FIELD]
+    def __init__(self, cache_root, secrets, client_id=None, client_token=None):
+        assert os.path.isdir(cache_root), "Cache root {} is not a dir.".format(cache_root)
+        self.repo_dir = os.path.join(cache_root, 'mozilla-unified')
 
-    task_id = taskcluster.get_last_task()
+        tc_client = TaskclusterClient(client_id, client_token)
 
-    task_data = taskcluster.get_task_details(task_id)
-    revision = task_data['payload']['env']['GECKO_HEAD_REV']
-    logger.info('Revision %s' % revision)
-    commit_sha = get_github_commit(revision)
-    logger.info('GitHub revision %s' % commit_sha)
+        required_fields = [COVERALLS_TOKEN_FIELD, CODECOV_TOKEN_FIELD]
+        secrets = tc_client.get_secrets(secrets, required_fields)
 
-    download_coverage_artifacts(task_id)
-
-    clone_mozilla_central(revision)
-    build_files()
-
-    output = generate_info(commit_sha, coveralls_token)
-
-    uploader.coveralls(output)
-    uploader.codecov(output, commit_sha, codecov_token)
-
-    coverage_by_dir.generate(REPO_DIR)
+        self.coveralls_token = secrets[COVERALLS_TOKEN_FIELD]
+        self.codecov_token = secrets[CODECOV_TOKEN_FIELD]


### PR DESCRIPTION
Fixes #296.

The best way to review these changes is by ignoring whitespace changes: https://github.com/mozilla-releng/services/pull/298/files?w=1.