### PR TITLE
shipit_code_coverage: Retrieve GitHub commit as late as possible and wait until the mapper is ready

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -50,6 +50,7 @@ class CodeCov(object):
 
     def get_github_commit(self, mercurial_commit):
         url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s'
+
         def get_commit():
             r = requests.get(url % mercurial_commit)
 

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -1,8 +1,9 @@
 import gzip
-import time
 import requests
 
 from cli_common.log import get_logger
+
+from shipit_code_coverage import utils
 
 
 logger = get_logger(__name__)
@@ -23,11 +24,16 @@ def coveralls(data):
 
 
 def coveralls_wait(job_url):
-    while True:
+    def check_coveralls_job():
         r = requests.get(job_url)
+
         if r.json()['covered_percent']:
-            break
-        time.sleep(60)
+            return True
+
+        return False
+
+    if utils.wait_until(check_coveralls_job, 60) is None:
+        raise Exception('Coveralls took too much time to injest data.')
 
 
 def codecov(data, commit_sha, flags, token):

--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -1,0 +1,13 @@
+import time
+
+
+def wait_until(operation, timeout=30):
+    elapsed = 0
+    while elapsed < timeout:
+        ret = operation()
+        if ret is not None:
+            return ret
+        time.sleep(60)
+        elapsed += 1
+
+    return None


### PR DESCRIPTION
If the task happens to be trigger right after a linux64-ccov build is finished, the commit might be missing on gecko-dev. We need to wait until it's available before proceeding.