### PR TITLE
shipit_risk_assessment: Fix requirements to load mocoda.

### DIFF
--- a/src/shipit_risk_assessment/requirements.txt
+++ b/src/shipit_risk_assessment/requirements.txt
@@ -1,3 +1,4 @@
 -e ./../../lib/cli_common[pulse,taskcluster,mercurial] #egg=mozilla-cli-common
 
 # mozilla-mocoda when it will be on PyPi
+-e https://github.com/mozilla/mocoda/archive/fb04724fd484bfcc949216decc15e2c2467b2f30.tar.gz #egg=mozilla-mocoda


### PR DESCRIPTION
Required to fix `project-releng/services-staging-shipit-risk-assessment-bot`