### PR TITLE
Debian derivatives have /bin/sh as dash

### DIFF
--- a/src/releng_docs/index.rst
+++ b/src/releng_docs/index.rst
@@ -34,7 +34,7 @@ Install Nix:
 
 .. code-block:: bash
 
-    % curl https://raw.githubusercontent.com/mozilla-releng/services/master/nix/setup.sh | sh
+    % curl https://raw.githubusercontent.com/mozilla-releng/services/master/nix/setup.sh | bash
 
 You can read more what above ``setup.sh`` script does in :ref:`prerequirements`
 section.


### PR DESCRIPTION
dash doesn't have the function builtin, causing errors here.