### PR TITLE
Change execution method to avoid import errors

### DIFF
--- a/src/shipit_signoff/README.md
+++ b/src/shipit_signoff/README.md
@@ -4,7 +4,8 @@
     pip install -r requirements.txt -r requirements-dev.txt -c requirements_frozen.txt 
     pip install -e . -c requirements_frozen.txt 
     Fill in `client_secrets.json.tmpl` as `client_secrets.json` for auth0 connections
-    python3 shipit_signoff/__init__.py
+    Set the environment variables APP_URL DATABASE_URL
+    FLASK_APP=shipit_signoff.flask:app flask run
 
 # Generating API documentation
 

--- a/src/shipit_signoff/shipit_signoff/__init__.py
+++ b/src/shipit_signoff/shipit_signoff/__init__.py
@@ -1,8 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-if __name__ == "__main__":
-    from shipit_signoff.flask import app
-
-    app.run(**app.run_options())


### PR DESCRIPTION
Running shipit_signoff/__init__.py caused ImportErrors because we had a file called flask.py, which was interfering with the import of the 'real' flask.

Change the execution method so that shipit_signoff doesn't get the __main__ namespace, so avoiding this issue.