### PR TITLE
shipit_code_coverage: Update grcov to version 0.1.16

### DIFF
--- a/nix/lib/crates.json
+++ b/nix/lib/crates.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/rust-lang/crates.io-index",
-  "rev": "f5aa2dc5b4aca680cd1648f4a3a97c66e5df82eb",
-  "date": "2017-04-04T01:35:18+00:00",
-  "sha256": "03ydaywx8fv4yipdzwg5pj0n1hrslbf7v21g3j5jd8nxprsilpc3",
+  "rev": "fb45baa83a02ec13a3a1b4b98cdb38932bb0fd38",
+  "date": "2017-05-22T08:38:44+00:00",
+  "sha256": "01mjp28a9lipfhdw8w7di1k42bnfid6wssbisdzcajlvfkhjplsc",
   "fetchSubmodules": true
 }

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -10,7 +10,7 @@ let
     if crates_json == null
       then crates_json_default
       else crates_json;
-  crates_version = "2017-04-04";
+  crates_version = "2017-05-22";
   crates_src = pkgs.fetchFromGitHub
     { owner = "rust-lang";
       repo = "crates.io-index";

--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -15,14 +15,14 @@ let
 
   # Marco grcov
   grcov = rustPlatform.buildRustPackage rec {
-    version = "0.1.13";
+    version = "0.1.16";
     name = "grcov-${version}";
 
     src = releng_pkgs.pkgs.fetchFromGitHub {
       owner = "marco-c";
       repo = "grcov";
       rev = "v${version}";
-      sha256 = "0b9xggvmfcy64mfxnqwayck0ldijvn4f2zkhkmgs3myiay7iv4v7";
+      sha256 = "1hzz6vjxg04damy392w878pjx2a9rhyw3lih6a73cpyignwj47lp";
     };
 
     # running 4 tests
@@ -46,7 +46,7 @@ let
     # error: test failed
     doCheck = false;
 
-    depsSha256 = "0pb7p9h47v82dab7hivka4faa0ilxw20dsdkkhv5j7lxjxwl5dhj";
+    depsSha256 = "089h324bzi5klm6k5ikngs0hxhid189idm8an7r790b56rc93z6a";
 
     meta = with releng_pkgs.pkgs.stdenv.lib; {
       description = "grcov collects and aggregates code coverage information for multiple source files.";

--- a/src/shipit_code_coverage/rust.nix
+++ b/src/shipit_code_coverage/rust.nix
@@ -11,7 +11,7 @@ in
 
 let
   crates_json = _pkgs.lib.importJSON ./crates.json;
-  crates_version = "2017-02-22";
+  crates_version = "2017-05-22";
   crates_src = _pkgs.fetchFromGitHub { owner = "rust-lang";
                                        repo = "crates.io-index";
                                        rev = crates_json.rev;


### PR DESCRIPTION
This version of grcov contains some performance improvements.
There's another performance improvement that is available when compiling with the nightly version of Rust, but I will enable it in a separate pull request.