### PR TITLE
shipit_code_coverage: Fix bug that prevented us from actually waiting for coveralls to injest data

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -162,9 +162,10 @@ class CodeCov(object):
 
         logger.info('Waiting for build to be injested by Coveralls...')
         # Wait until the build has been injested by Coveralls.
-        for coveralls_job in coveralls_jobs:
-            uploader.coveralls_wait(coveralls_job)
-        logger.info('Build injested by coveralls')
+        if all([uploader.coveralls_wait(job_url) for job_url in coveralls_jobs]):
+            logger.info('Build injested by coveralls')
+        else:
+            logger.info('Coveralls took too much time to injest data.')
 
         coverage_by_dir.generate(self.repo_dir)
 

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -28,14 +28,9 @@ def coveralls(data):
 def coveralls_wait(job_url):
     def check_coveralls_job():
         r = requests.get(job_url)
+        return True if r.json()['covered_percent'] else False
 
-        if r.json()['covered_percent']:
-            return True
-
-        return False
-
-    if utils.wait_until(check_coveralls_job, 60) is None:
-        raise Exception('Coveralls took too much time to injest data.')
+    return utils.wait_until(check_coveralls_job, 60) is not None
 
 
 def codecov(data, commit_sha, token, flags=None):

--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -5,7 +5,7 @@ def wait_until(operation, timeout=30):
     elapsed = 0
     while elapsed < timeout:
         ret = operation()
-        if ret is not None:
+        if ret:
             return ret
         time.sleep(60)
         elapsed += 1


### PR DESCRIPTION
The `check_coveralls_job` function is returning `True` when the build is injested and `False` when it isn't. The `wait_until` function was checking for the return value to be not `None`. This meant that, even when the build was not injested and `check_coveralls_job` returned False, `wait_until` was completing.

With this change, we are actually waiting coveralls to injest the build before generating the coverage by dir report.
I've removed the code which raised an exception when Coveralls fails to injest a report, as it's too likely to happen for now.