### PR TITLE
shipit_static_analysis: Parse clang-tidy output to extract detected code problems.

### DIFF
--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -32,10 +32,13 @@ class HookStaticAnalysis(Hook):
             return
 
         # Extract commits
-        commits = [c['rev'] for c in payload.get('commits', [])]
+        commits = [
+            '{rev}:{review_request_id}:{diffset_revision}'.format(**c)
+            for c in payload.get('commits', [])
+        ]
         logger.info('Received new commits', commits=commits)
         return {
-            'REVISIONS': ' '.join(commits),
+            'COMMITS': ' '.join(commits),
         }
 
 

--- a/src/shipit_static_analysis/default.nix
+++ b/src/shipit_static_analysis/default.nix
@@ -27,6 +27,12 @@ let
           # Used by taskclusterProxy
           ("secrets:get:" + secretsKey)
 
+          # Send emails to relman
+          "notify:email:jan@mozilla.com"
+          "notify:email:andi@mozilla.com"
+          "notify:email:marco@mozilla.com"
+          "notify:email:sledru@mozilla.com"
+
           # Used by cache
           ("docker-worker:cache:" + cacheKey)
         ];

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -166,7 +166,7 @@ class Workflow(object):
         # Notify by email
         if issues:
             logger.info('Send email to admins')
-            self.notify_admins(issues)
+            self.notify_admins(review_request_id, issues)
 
     def parse_issues(self, clang_output):
         """
@@ -206,14 +206,16 @@ class Workflow(object):
 
         return issues
 
-    def notify_admins(self, issues):
+    def notify_admins(self, review_request_id, issues):
         """
         Send an email to administrators
         """
+        review_url = 'https://reviewboard.mozilla.org/r/' + review_request_id + '/'
+        content = review_url + '\n\n' + '\n'.join([i.as_markdown() for i in issues])
         for email in self.emails:
             self.notify.email({
                 'address': email,
-                'subject': 'Static analysis problem',
-                'content': '\n'.join([i.as_markdown() for i in issues]),
+                'subject': 'New Static Analysis Review',
+                'content': content,
                 'template': 'fullscreen',
             })


### PR DESCRIPTION
This change processes the clang-tidy output to extract potentially detected code problems in order to generate a review (as an email report first, and soon a proper drive-by review on MozReview).