### PR TITLE
Improve various aspects of trychooser around plaform selection for tests.

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -206,6 +206,10 @@
             </li>
 
             <li>
+              <label><input type="checkbox" value="Windows 10">Win10 (win64) (disabled when not explicitly checked)</label>
+            </li>
+
+            <li>
               <label><input type="checkbox" value="Android 4.3">Android 4.3 API15+</label>
             </li>
 

--- a/src/releng_frontend/src/static/trychooser/trychooser.js
+++ b/src/releng_frontend/src/static/trychooser/trychooser.js
@@ -201,6 +201,8 @@ $(document).ready(function() {
             });
             if (filters.length > 0 && names != 'none') {
                 filters = resolveFilters(filters).join(',');
+                // For command line output, we need to escape the backslashes here.
+                filters = filters.replace(/ /g, "\\ ");
                 names = names.map(function (n) { return n + '[' + filters + ']'; });
             }
 
@@ -269,8 +271,15 @@ $(document).ready(function() {
             value = "(NO JOBS CHOSEN)";
             $('.result').val(value);
         } else {
-            $('#result_try').val('try: ' + value);
             $('#result_mach').val('./mach try ' + value);
+
+            // The simple try syntax that is passed to the parent shouldn't have
+            // slashes in it, so we elimate them here. This is simpler than trying
+            // to insert slashes after we've generated the value, or to be
+            // generating the value twice.
+            value = value.replace(/\\/g, "");
+
+            $('#result_try').val('try: ' + value);
         }
         if (isEmbedded && window.parent) {
             if (incomplete) {

--- a/src/releng_frontend/src/static/trychooser/trychooser.js
+++ b/src/releng_frontend/src/static/trychooser/trychooser.js
@@ -199,7 +199,7 @@ $(document).ready(function() {
             $('[try-filter=' + filter_tryopt + '] :checked').each(function () {
                 filters.push.apply(filters, $(this).attr('value').split(','));
             });
-            if (filters.length > 0) {
+            if (filters.length > 0 && names != 'none') {
                 filters = resolveFilters(filters).join(',');
                 names = names.map(function (n) { return n + '[' + filters + ']'; });
             }
@@ -282,4 +282,3 @@ $(document).ready(function() {
 
     }
 });
-


### PR DESCRIPTION
This PR:

- Adds Windows 10 to the list of available test platforms.
- Stops including platform restrictions when 'none' is chosen ([Bug 1276393](https://bugzilla.mozilla.org/show_bug.cgi?id=1276393))
- Escapes spaces on the example ./mach command ([Bug 1243709](https://bugzilla.mozilla.org/show_bug.cgi?id=1243709))