### PR TITLE
shipit_tasklcuster: initial MVP

### DIFF
--- a/src/shipit_taskcluster/shipit_taskcluster/api.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/api.py
@@ -4,6 +4,120 @@
 
 from __future__ import absolute_import
 
+import logging
+import datetime
 
-def example():
+from flask import request, abort
+from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.exc import IntegrityError
+
+from backend_common.db import db
+from shipit_taskcluster.models import TaskclusterStatus, TaskclusterStep
+from shipit_taskcluster.taskcluster_utils import get_taskcluster_tasks_state
+
+log = logging.getLogger(__name__)
+
+
+# api
+def list_taskcluster_steps(state="running"):
+    log.info('listing steps')
+
+    try:
+        desired_state = TaskclusterStatus[state]
+    except KeyError:
+        exception = "{} is not a valid state".format(state)
+        log.warning("valid states: %s", [state.value for state in TaskclusterStatus])
+        log.exception(exception)
+        abort(400, exception)
+
+    try:
+        steps = db.session.query(TaskclusterStep).filter(TaskclusterStep.state == desired_state).all()
+    except NoResultFound:
+        abort(404, "No Taskcluster steps found with that given state.")
+
+    log.info("listing steps: {}", steps)
+    return [step.uid for step in steps]
+
+
+def get_taskcluster_step_status(uid):
+    """
+    Get the current status of a taskcluster step
+    """
+    log.info('getting step status %s', uid)
+
+    try:
+        step = db.session.query(TaskclusterStep).filter(TaskclusterStep.uid == uid).one()
+    except NoResultFound:
+        abort(404)
+
+    if not step.state.value == "completed":
+        # only poll taskcluster if the step is not resolved successfully
+        # this is so the shipit taskcluster step can still be manually overridden as complete
+
+        task_group_state = get_taskcluster_tasks_state(step.task_group_id, step.scheduler_api)
+
+        if step.state.value != task_group_state:
+            # update step status!
+            if task_group_state in ["completed", "failed", "exception"]:
+                step.finished = datetime.datetime.utcnow()
+            step.state = task_group_state
+            db.session.commit()
+
+    return dict(uid=step.uid, task_group_id=step.task_group_id, state=step.state.value,
+                finished=step.finished or "", created=step.created)
+
+
+def get_taskcluster_step(uid):
+    log.info('getting step %s', uid)
+
+    try:
+        step = db.session.query(TaskclusterStep).filter(TaskclusterStep.uid == uid).one()
+    except NoResultFound:
+        abort(404, "taskcluster step not found")
+
+    return dict(uid=step.uid, taskGroupId=step.task_group_id,
+                schedulerAPI=step.scheduler_api, parameters={})
+
+
+def create_taskcluster_step(uid, body):
+    """creates taskcluster step"""
+
+    step = TaskclusterStep()
+
+    step.uid = uid
+    step.state = 'running'
+    step.task_group_id = body["taskGroupId"]
+    step.scheduler_api = body["schedulerAPI"]
+
+    log.info('creating taskcluster step %s for task_group_id %s', step.uid, step.task_group_id)
+    db.session.add(step)
+
+    try:
+        db.session.commit()
+    except IntegrityError as e:
+        # TODO is there a better way to do this?
+        if "shipit_taskcluster_steps_pkey" in str(e):
+            title = 'Step with that uid already exists'
+        elif "shipit_taskcluster_steps_task_group_id_key" in str(e):
+            title = 'Step with that task_group_id already exists'
+        else:
+            title = 'Integrity Error'
+        return {'error_title': title, 'error_message': str(e)}, 409
+
+    return None
+
+
+def delete_taskcluster_step(uid):
+    log.info('deleting step %s', uid)
+
+    try:
+        step = TaskclusterStep.query.filter_by(uid=uid).one()
+    except Exception as e:
+        exception = "Taskcluster step could not be found by given uid: {}".format(uid)
+        log.exception(exception)
+        abort(404, exception)
+
+    db.session.delete(step)
+    db.session.commit()
+
     return {}

--- a/src/shipit_taskcluster/shipit_taskcluster/api.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/api.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import logging
 import datetime
 
-from flask import request, abort
+from flask import abort
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
 

--- a/src/shipit_taskcluster/shipit_taskcluster/api.yml
+++ b/src/shipit_taskcluster/shipit_taskcluster/api.yml
@@ -9,9 +9,118 @@ produces:
   - application/json
 paths:
 
-  /example:
+  /steps:
     get:
-      operationId: "shipit_taskcluster.api.example"
+      operationId: "shipit_taskcluster.api.list_taskcluster_steps"
+      description: List all Taskcluster steps with status
+      parameters:
+        - name: state
+          in: query
+          required: false
+          default: running
+          type: string
       responses:
         200:
-          description: Example
+          description: List of all steps
+
+  /steps/{uid}/status:
+    get:
+      operationId: "shipit_taskcluster.api.get_taskcluster_step_status"
+      description: Status of a Taskcluster step
+      parameters:
+        - $ref: "#/parameters/uid"
+      responses:
+        200:
+          description: Status of a Taskcluster step
+          schema:
+            $ref: '#/definitions/StepResult'
+
+  /steps/{uid}:
+    put:
+      operationId: "shipit_taskcluster.api.create_taskcluster_step"
+      description: Create new Taskcluster step
+      parameters:
+        - $ref: '#/parameters/uid'
+        - name: body
+          in: body
+          description: inputs to create Taskcluster step
+          required: true
+          schema:
+            $ref: '#/definitions/TaskclusterStep'
+      responses:
+        200:
+          description: Returns nothing
+          schema:
+            type: string
+        409:
+          description: A step with this uid or task_group_id already exists
+    get:
+      operationId: "shipit_taskcluster.api.get_taskcluster_step"
+      description: "Step definition"
+      parameters:
+          - $ref: '#/parameters/uid'
+      responses:
+        200:
+          description: "Definition of a TaskclusterStep"
+          schema:
+            $ref: '#/definitions/TaskclusterStep'
+    delete:
+      operationId: "shipit_taskcluster.api.delete_taskcluster_step"
+      description: Remove a Taskcluster step
+      parameters:
+        - $ref: '#/parameters/uid'
+      responses:
+        200:
+          description: Removed Taskcluster step
+
+definitions:
+
+  # TODO move this to a common place
+  StepResult:
+    type: object
+    required:
+      - state
+    properties:
+      state:
+        type: string
+        enum:
+          - pending
+          - running
+          - exception
+          - completed
+          - failed
+      message:
+        type: string
+        description: More elaborate description of state for humans.
+      created:
+        type: "string"
+      finished:
+        type: "string"
+
+  # TODO make this a generic step and move it to common place
+  TaskclusterStep:
+    type: object
+    description: A representation of Taskcluster group of Tasks
+    required:
+      - taskGroupId
+      - schedulerAPI
+    properties:
+      uid:
+        type: string
+      taskGroupId:
+        type: string
+        description: the group id that is shared between tasks
+      schedulerAPI:
+        type: boolean
+        default: false
+        description: |
+          if true, use taskcluster's old scheduler api. Note, the scheduler api has been deprecated
+          in favour of task.dependencies and should only be used for backwards support.
+
+parameters:
+  uid:
+    name: uid
+    in: path
+    description: Step UID
+    required: true
+    type: string

--- a/src/shipit_taskcluster/shipit_taskcluster/models.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/models.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import
+
+import datetime
+import enum
+
+import sqlalchemy as sa
+
+# TODO install backend to venv
+from backend_common.db import db
+
+
+# TODO use shared step backend base class for statuses
+class TaskclusterStatus(enum.Enum):
+    pending = 'pending'
+    running = 'running'
+    exception = 'exception'
+    completed = 'completed'
+    failed = 'failed'
+
+
+# TODO use shared step backend base class for db steps
+class TaskclusterStep(db.Model):
+    """
+    Recording taskcluster steps as distinct entities
+    """
+
+    __tablename__ = 'shipit_taskcluster_steps'
+
+    uid = sa.Column(sa.String(80), primary_key=True)
+    state = sa.Column(sa.Enum(TaskclusterStatus), default=TaskclusterStatus.pending)
+    created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
+    finished = sa.Column(sa.DateTime, nullable=True)
+    task_group_id = sa.Column(sa.String(80), nullable=False, unique=True)
+    scheduler_api = sa.Column(sa.Boolean, nullable=False, default=False)

--- a/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
@@ -1,0 +1,47 @@
+import logging
+
+import taskcluster
+
+log = logging.getLogger(__name__)
+
+TC_QUEUE = taskcluster.Queue()
+TC_SCHEDULER = taskcluster.Scheduler()
+
+
+TASK_GRAPH_STATE_TO_STEP_STATE = {
+    "running": "running",
+    "blocked": "failed",
+    "finished": "completed"
+}
+
+
+def get_taskcluster_tasks_state(task_group_id, scheduler_api=False):
+    # TODO rather than poll taskcluster queue and scheduler for state
+    # we should use pulse and listen in for status changes
+    if scheduler_api:
+        return get_scheduler_graph_state(task_graph_id=task_group_id)
+    return get_task_group_state(task_group_id)
+
+
+
+def get_scheduler_graph_state(task_graph_id):
+    """poll the scheduler for overall status.
+    this request is relatively cheap.
+    :returns state where state is of: running, blocked or finished"""
+    try:
+        return TASK_GRAPH_STATE_TO_STEP_STATE[TC_SCHEDULER.status(task_graph_id)["status"]["state"]]
+    except Exception:
+        state = "exception"
+        log.exception("Could not determine status from taskcluster scheduler with graph id: %s",
+                      task_graph_id)
+        return state
+
+
+
+def get_queue_group_state(task_group_id):
+    # TODO
+    # the python taskcluster package doesn't actually support the limit or
+    # continuationToken query strings, so we can't get a subset or more than 1000
+    # tasks
+    # group = TC_QUEUE.listTaskGroup(taskGroupId)
+    pass

--- a/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
@@ -20,8 +20,7 @@ def get_taskcluster_tasks_state(task_group_id, scheduler_api=False):
     # we should use pulse and listen in for status changes
     if scheduler_api:
         return get_scheduler_graph_state(task_graph_id=task_group_id)
-    return get_task_group_state(task_group_id)
-
+    return get_queue_group_state(task_group_id)
 
 
 def get_scheduler_graph_state(task_graph_id):
@@ -35,7 +34,6 @@ def get_scheduler_graph_state(task_graph_id):
         log.exception("Could not determine status from taskcluster scheduler with graph id: %s",
                       task_graph_id)
         return state
-
 
 
 def get_queue_group_state(task_group_id):


### PR DESCRIPTION
before this bitrots, let's get this into production.

next steps after this lands:

* auth support
* rip out common step logic into backend_common/shipit_steps or something.


@garbas @nthomas-mozilla what do you think?