### PR TITLE
shipit_static_analysis: Enable clang-tidy checkers for dead code, else-after-return and mozilla-*

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -141,6 +141,7 @@ class Workflow(object):
         logger.info('Run clang-tidy...')
         checks = [
             '-*',
+            'clang-analyzer-deadcode.DeadStores',
             'modernize-loop-convert',
             'modernize-use-auto',
             'modernize-use-default',
@@ -148,6 +149,8 @@ class Workflow(object):
             'modernize-use-bool-literals',
             'modernize-use-override',
             'modernize-use-nullptr',
+            'mozilla-*',
+            'readability-else-after-return',
         ]
         cmd = [
             'run-clang-tidy.py',


### PR DESCRIPTION
This change tentatively enables the following clang-tidy checkers:
- `clang-analyzer-deadcode.DeadStores`: to report dead / unreachable code
- `readability-else-after-return`: to suggest simplifying things like `if (...) { return nullptr; } else { ... }` to `if (...) ' return nullptr; } ...` (no `else` needed)

It also enables checkers that are prefixed with `mozilla-`, however upstream `clang-tidy` doesn't have any (so enabling `mozilla-*` acivates 0 additional checkers). I'm simply adding this rule so that when we switch to a Mozilla-specific checkers, its own `mozilla-*` rules will already be enabled.