### PR TITLE
shipit_static_analysis: Improve markdown export for code issues (#373).

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -19,6 +19,24 @@ REPO_REVIEW = b'https://reviewboard-hg.mozilla.org/gecko'
 
 REGEX_HEADER = re.compile(r'^(.+):(\d+):(\d+): (warning|error|note): (.*)\n', re.MULTILINE)
 
+ISSUE_MARKDOWN = '''
+## {type}
+**Message**: {message}
+**Location**: {location}
+```
+{body}
+```
+{notes}
+'''
+
+ISSUE_NOTE_MARKDOWN = '''
+**Note**: {message}
+**Location**: {location}
+```
+{body}
+```
+'''
+
 
 class Issue(object):
     """
@@ -42,25 +60,19 @@ class Issue(object):
         return self.type in ('warning', 'error')
 
     def as_markdown(self):
-        out = [
-            '## {}'.format(self.type),
-            '**Message**: {}'.format(self.message),
-            '**Location**: {}:{}:{}'.format(self.path, self.line, self.char),
-            '```',
-            '{}'.format(self.body),
-            '```',
-            '',
-        ]
-        for n in self.notes:
-            out += [
-                '**Note**: {}'.format(n.message),
-                '**Location**: {}:{}:{}'.format(n.path, n.line, n.char),
-                '```',
-                '{}'.format(self.body),
-                '```',
-                '',
-            ]
-        return '\n'.join(out)
+        return ISSUE_MARKDOWN.format(
+            type=self.type,
+            message=self.message,
+            location="{}:{}:{}".format(self.path, self.line, self.char),
+            body=self.body,
+            notes='\n'.join([
+                ISSUE_NOTE_MARKDOWN.format(
+                    message=n.message,
+                    location='{}:{}:{}'.format(n.path, n.line, n.char),
+                    body=n.body,
+                ) for n in self.notes
+            ]),
+        )
 
 
 class Workflow(object):

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -43,17 +43,23 @@ class Issue(object):
 
     def as_markdown(self):
         out = [
-            '# {} : {}'.format(self.type, self.path),
-            '**Position**: {}:{}'.format(self.line, self.char),
-            '**Snippet**: {}'.format(self.message),
+            '## {}'.format(self.type),
+            '**Message**: {}'.format(self.message),
+            '**Location**: {}:{}:{}'.format(self.path, self.line, self.char),
+            '```',
+            '{}'.format(self.body),
+            '```',
             '',
         ]
-        out += [
-            '* note on {} at {}:{} : {}'.format(
-                n.path, n.line, n.char, n.message
-            )
-            for n in self.notes
-        ]
+        for n in self.notes:
+            out += [
+                '**Note**: {}'.format(n.message),
+                '**Location**: {}:{}:{}'.format(n.path, n.line, n.char),
+                '```',
+                '{}'.format(self.body),
+                '```',
+                '',
+            ]
         return '\n'.join(out)
 
 


### PR DESCRIPTION
As mentioned in #373, the generated markdown in static analysis email reports is slightly broken.

In this pull request, I attempt to improve it. I'm not too confident with Python, but the result should look something like this:

## Warning
**Message**: converting integer literal to bool, use bool literal instead [modernize-use-bool-literals]
**Location**: accessible/atk/AccessibleWrap.cpp:139:3
```
        uint32_t* hdr = reinterpret_cast<uint32_t*>(start);
        ^
        auto
```
**Note**: obj-x86_64-pc-linux-gnu/dist/include/nsDebug.h:105:67
**Message**: expanded from macro 'NS_ASSERTION'
```
        NS_ASSERTION(0)
                     ^
                     false
```

(Note: The contents of my example don't make any sense, please pay only attention to the form.)