### PR TITLE
Add android-aarch64 to trychooser

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -97,6 +97,9 @@
                 <label><input type="checkbox" name="platform" value="android-x86">android-x86 (Android 4.2)</label>
             </li>
             <li>
+                <label><input type="checkbox" name="platform" value="android-aarch64">android-aarch64 (Android 5.0)</label>
+            </li>
+            <li>
                 <label><input type="checkbox" name="platform" value="sm-arm-sim">Spidermonkey arm-sim</label>
             </li>
             <!-- TODO: Currently not supported, enable when it is


### PR DESCRIPTION
Since landed bug 1366404, we add android-aarch64 to treeherder.  So we should add this to trychooser too.

cc: @darchons 