### PR TITLE
shipit_static_analysis: Fix #412 by making clang-tidy regex accept messages including characters '()='.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/clang.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang.py
@@ -15,7 +15,7 @@ from cli_common.log import get_logger
 
 logger = get_logger(__name__)
 
-REGEX_HEADER = re.compile(r'^(.+):(\d+):(\d+): (warning|error|note): ([\w\s\.\'\"^_,-<>]+)(?: \[([\.\w-]+)\])?\n', re.MULTILINE)
+REGEX_HEADER = re.compile(r'^(.+):(\d+):(\d+): (warning|error|note): ([\w\s\.\'\"^_,-<=>\(\)]+)(?: \[([\.\w-]+)\])?\n', re.MULTILINE)
 
 ISSUE_MARKDOWN = '''
 ## {type}


### PR DESCRIPTION
This turned out to be a pretty quick fix.

However, our regex is becoming convoluted, and I'm wondering if we shouldn't use something simpler like:

```regex
^(.+):(\d+):(\d+): (warning|error|note): ([^\[\]\n]+)(?: \[([\.\w-]+)\])?\n
```

(basically, the description can be anything in a given line except `[` or `]`).