### PR TITLE
[WIP] shipit_static_analysis: Post static analysis feedback to MozReview.

### DIFF
--- a/nix/requirements_override.nix
+++ b/nix/requirements_override.nix
@@ -250,4 +250,13 @@ in skipOverrides {
     '';
   };
 
+  "RBTools" = self: old: {
+    patches = [
+         (pkgs.fetchurl {
+           url = "https://github.com/La0/rbtools/commit/190b4adb768897f65cf7ec57806649bc14c8e45d.diff";
+           sha256 = "1hh6i3cffsc4fxr4jqlxralnf78529i0pspm7jn686a2s6bh26mw";
+         })
+      ];
+  };
+
 }

--- a/src/shipit_static_analysis/shipit_static_analysis/clang.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang.py
@@ -125,6 +125,9 @@ class ClangTidy(object):
         '''
         The actual clang-tidy worker, working on the queue
         '''
+        self.all_checks = [c['name'] for c in checks]
+        self.enabled_checks = [c['name'] for c in checks if c['enabled']]
+
         while True:
             # Get new filename to work on
             filename = self.queue_workers.get()
@@ -134,7 +137,7 @@ class ClangTidy(object):
                 self.binary,
                 # Show warnings in all in-project headers by default.
                 '-header-filter=^{}/.*'.format(os.path.basename(self.build_dir)),
-                '-checks={}'.format(','.join(checks)),
+                '-checks={}'.format(','.join(all_checks)),
                 '-p={}'.format(self.build_dir),
                 filename,
             ]
@@ -197,7 +200,7 @@ class ClangIssue(object):
     '''
     An issue reported by clang-tidy
     '''
-    def __init__(self, header_data, work_dir):
+    def __init__(self, header_data, work_dir, enabled_checks):
         assert isinstance(header_data, tuple)
         assert len(header_data) == 6
         self.path, self.line, self.char, self.type, self.message, self.check = header_data  # noqa
@@ -207,6 +210,9 @@ class ClangIssue(object):
         self.char = int(self.char)
         self.body = None
         self.notes = []
+
+        # Will this issue be posted on MozReview ?
+        self.is_mozreview = self.check in enabled_checks and self.is_problem()
 
     def __str__(self):
         return '[{}] {} {}:{}'.format(self.type, self.path, self.line, self.char)
@@ -229,3 +235,22 @@ class ClangIssue(object):
                 ) for n in self.notes
             ]),
         )
+
+    def build_mozreview(self, review):
+        """
+        Build comment for this issue on MozReview
+        """
+        if not self.is_mozreview:
+            return
+
+        # Check this path is not in tools/rewriting/ThirdPartyPaths.txt
+
+        # Is this line in patch ?
+
+        # Convert line
+
+        # Build MozReview Comment
+        message = 'Issue found by static analysis bot:\n{}\n{}'.format(
+            self.message, self.body
+        )
+        review.comment(self.path, line, num_lines, message)

--- a/src/shipit_static_analysis/shipit_static_analysis/cli.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/cli.py
@@ -14,7 +14,7 @@ import click
 import logging
 import re
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('shipit_static_analysis')
 
 REGEX_COMMIT = re.compile(r'(\w+):(\d+):(\d+)')
 
@@ -53,6 +53,14 @@ def main(commits,
                  taskcluster_client_id,
                  taskcluster_access_token,
                  )
+
+    if 'MOZREVIEW_USER' in secrets and 'MOZREVIEW_API_KEY' in secrets:
+        w.setup_mozreview(
+            secrets['MOZREVIEW_USER'],
+            secrets['MOZREVIEW_API_KEY'],
+        )
+    else:
+        logger.info('No MozReview credentials, skipping.')
 
     for commit in REGEX_COMMIT.findall(commits):
         w.run(*commit)

--- a/src/shipit_static_analysis/shipit_static_analysis/config.yml
+++ b/src/shipit_static_analysis/shipit_static_analysis/config.yml
@@ -2,19 +2,33 @@ target: obj-x86_64-pc-linux-gnu
 
 # All the clang checks used by the bot
 clang_checkers:
- - -*
- - clang-analyzer-deadcode.DeadStores
- - modernize-loop-convert
- - modernize-raw-string-literal
+ - name: -*
+   mozreview: no
+ - name: clang-analyzer-deadcode.DeadStores
+   mozreview: no
+ - name: modernize-loop-convert
+   mozreview: yes
+ - name: modernize-raw-string-literal
+   mozreview: yes
 # modernize-use-auto (controversial, see bug 1371052)
 # modernize-use-bool-literals (too noisy because of `while (0)` in many macros)
- - modernize-use-equals-default
- - modernize-use-equals-delete
- - modernize-use-nullptr
- - modernize-use-override
- - mozilla-*
- - performance-faster-string-find
- - performance-for-range-copy
- - readability-else-after-return
- - readability-misleading-indentation
- - readability-redundant-control-flow
+ - name: modernize-use-equals-default
+   mozreview: yes
+ - name: modernize-use-equals-delete
+   mozreview: yes
+ - name: modernize-use-nullptr
+   mozreview: yes
+ - name: modernize-use-override
+   mozreview: no
+ - name: mozilla-*
+   mozreview: no
+ - name: performance-faster-string-find
+   mozreview: yes
+ - name: performance-for-range-copy
+   mozreview: yes
+ - name: readability-else-after-return
+   mozreview: yes
+ - name: readability-misleading-indentation
+   mozreview: yes
+ - name: readability-redundant-control-flow
+   mozreview: yes

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -13,7 +13,6 @@ from cli_common.taskcluster import get_service
 from cli_common.log import get_logger
 from cli_common.command import run_check
 from rbtools.api.client import RBClient
-from rbtools.api.errors import APIError
 from shipit_static_analysis.clang import ClangTidy
 from shipit_static_analysis.batchreview import BatchReview
 
@@ -28,6 +27,7 @@ class Workflow(object):
     Static analysis workflow
     '''
     taskcluster = None
+    mozreview = None
 
     def __init__(self, cache_root, emails, client_id=None, access_token=None):
         self.emails = emails
@@ -47,17 +47,6 @@ class Workflow(object):
         self.config = yaml.load(open(config_path))
         assert 'clang_checkers' in self.config
         assert 'target' in self.config
-
-        # Create new MozReview API client
-        url = 'https://reviewboard.mozilla.org'
-        username = 'jkeromnes+clangbot@mozilla.com'
-        apikey = '(secret)'
-        rbc = RBClient(url, save_cookies=False, allow_caching=False)
-        login_resource = rbc.get_path(
-            'extensions/mozreview.extension.MozReviewExtension/'
-            'bugzilla-api-key-logins/')
-        login_resource.create(username=username, api_key=apikey)
-        self.api_root = rbc.get_root()
 
         # Clone mozilla-central
         self.repo_dir = os.path.join(self.cache_root, 'static-analysis/')
@@ -81,6 +70,18 @@ class Workflow(object):
 
         # Setup clang
         self.clang = ClangTidy(self.repo_dir, self.config['target'])
+
+    def setup_mozreview(self, username, api_key):
+        '''
+        Use mozreview client to post results
+        '''
+        url = 'https://reviewboard.mozilla.org'
+        path = 'extensions/mozreview.extension.MozReviewExtension/bugzilla-api-key-logins/' # noqa
+        rbc = RBClient(url, save_cookies=False, allow_caching=False)
+        login_resource = rbc.get_path(path)
+        login_resource.create(username=username, api_key=api_key)
+        self.mozreview = rbc.get_root()
+        logger.info('Connected to MozReview', username=username)
 
     def run(self, revision, review_request_id, diffset_revision):
         '''
@@ -154,7 +155,8 @@ class Workflow(object):
         '''
         Post review comments to MozReview in a single batch
         '''
-        review = BatchReview(self.api_root, review_request_id, diffset_revision)
+        review = BatchReview(self.mozreview, review_request_id, diffset_revision)
+        print(review)
         # review.comment(filename, line, num_lines, comment)
         # review.publish(body_top='\n'.join(commentlines),
         #                ship_it=false)

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -130,12 +130,15 @@ class Workflow(object):
 
         logger.info('Detected {} code issue(s)'.format(len(issues)))
 
-        # Notify by email
         if issues:
+            # Notify by email
             logger.info('Send email to admins')
             self.notify_admins(review_request_id, issues)
-            logger.info('Post issues to MozReview')
-            self.post_review(review_request_id, diffset_revision, issues)
+
+            # Post on MozReview when available
+            if self.mozreview:
+                logger.info('Post issues to MozReview')
+                self.post_review(review_request_id, diffset_revision, issues)
 
     def notify_admins(self, review_request_id, issues):
         '''
@@ -156,7 +159,6 @@ class Workflow(object):
         Post review comments to MozReview in a single batch
         '''
         review = BatchReview(self.mozreview, review_request_id, diffset_revision)
-        print(review)
-        # review.comment(filename, line, num_lines, comment)
-        # review.publish(body_top='\n'.join(commentlines),
-        #                ship_it=false)
+        for issue in issues:
+            issue.build_mozreview(review)
+        review.publish(ship_it=False)


### PR DESCRIPTION
I basically followed the steps from #364 to start implementing the export of detected code issues as MozReview comments.

Here is what still needs to be done:
- [x] Store and retrieve our bot's API key as a TaskCluster secret
- [ ] Finish export from internal `issues` representation to `review.comment()`
- [ ] Use `review.translate_line_num(filename, line_num, original=False)` and `review.changed_lines_for_file(filename)` to compute the correct line numbers expected by MozReview, and  "ignore"* issues detected on lines that were not actually changed by the patch author.
- [ ] Tweak which code issues we report in order to only produce valuable feedback (today, there are many false positives, e.g. macro-related problems that are repeated many times)
- [ ] Test the MozReview export (to make sure it works fine, review comments look useful, and nothing breaks)

* But maybe we should still count occurrences of same type, so that if the author does introduce a new code issue of this type, we can add "FYI there are 5 other occurrences of this issue type in this file" to our review comment (maybe they'll feel like drive-by fixing the 5 other issues).