### PR TITLE
nix: Update nixpkgs to get latest rust 1.17

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,7 +16,7 @@ let
       update = releng_pkgs.lib.updateFromGitHub {
         owner = "NixOS";
         repo = "nixpkgs-channels";
-        branch = "nixos-17.03";
+        branch = "nixos-unstable";
         path = "nix/nixpkgs.json";
       };
     };

--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -49,7 +49,7 @@ in gecko.overrideDerivation (old: {
   propagatedBuildInputs = old.propagatedBuildInputs
     ++ [
 
-      # Update rust to 1.15
+      # Update rust to 1.17
       rustStable.rustc
       rustStable.cargo
     ];

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
-  "repo": "nixpkgs-channels",
-  "rev": "5acb454e2ad3e3783e63b86a9a31e800d2507e66",
-  "sha256": "03pd054znjsn4kjdx2k4y73hjsz65wwkirkp4jmmbb396igiagq3"
+  "repo": "nixpkgs",
+  "rev": "504a2d29d71f2667140d887bad3c8692d283bf5b",
+  "sha256": "1775qvrsm978mq3hs5bc2kyn1nrsiqv9dfydwj8y95qmq7qr43bw"
 }

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,6 +1,6 @@
 {
   "owner": "NixOS",
-  "repo": "nixpkgs",
-  "rev": "504a2d29d71f2667140d887bad3c8692d283bf5b",
-  "sha256": "1775qvrsm978mq3hs5bc2kyn1nrsiqv9dfydwj8y95qmq7qr43bw"
+  "repo": "nixpkgs-channels",
+  "rev": "0d4431cfe90b2242723ccb1ccc90714f2f68a609",
+  "sha256": "0iil6dx91widz66avnbs4m8lhygmadhyma1m2kbq57iwj73yql3w"
 }

--- a/nix/requirements_override.nix
+++ b/nix/requirements_override.nix
@@ -213,7 +213,7 @@ in skipOverrides {
     patches = [
          (pkgs.fetchurl {
            url = "https://github.com/benoitc/gunicorn/pull/1527.patch";
-           sha256 = "03wpbcn03vf08vc5jz7sbb8xlvhmkas1h1l0wvp2mn0dhcrbipkh";
+           sha256 = "14zvlm4dh432gd5n32i2x60rkq3d8wz1xlj45ldkp2z4qgp7chbk";
          })
       ];
   };


### PR DESCRIPTION
I'm using the latest revision of nixpkgs-unstable, as Nix pkgs for 17.03 do not have rust 1.17