### PR TITLE
shipit_code_coverage: Use REVISION passed as argument if available, otherwise use latest linux64-ccov task.

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/cli.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/cli.py
@@ -15,17 +15,18 @@ from shipit_code_coverage import config
 
 @click.command()
 @taskcluster_options
+@click.option('--revision', envvar='REVISION')
 @click.option(
     '--cache-root',
     required=True,
     help='Cache root, used to pull changesets'
 )
-def main(cache_root,
+def main(revision,
+         cache_root,
          taskcluster_secret,
          taskcluster_client_id,
          taskcluster_access_token,
          ):
-
     secrets = get_secrets(taskcluster_secret,
                           config.PROJECT_NAME,
                           required=(
@@ -43,7 +44,8 @@ def main(cache_root,
                 MOZDEF=secrets.get('MOZDEF'),
                 )
 
-    c = CodeCov(cache_root,
+    c = CodeCov(revision,
+                cache_root,
                 secrets[config.COVERALLS_TOKEN_FIELD],
                 secrets[config.CODECOV_TOKEN_FIELD],
                 )

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 
 class CodeCov(object):
 
-    def __init__(self, cache_root, coveralls_token, codecov_token):
+    def __init__(self, revision, cache_root, coveralls_token, codecov_token):
         # List of test-suite, sorted alphabetically.
         # This way, the index of a suite in the array should be stable enough.
         self.suites = []
@@ -28,6 +28,16 @@ class CodeCov(object):
 
         self.coveralls_token = coveralls_token
         self.codecov_token = codecov_token
+
+        if revision is None:
+            self.task_id = taskcluster.get_last_task()
+
+            task_data = taskcluster.get_task_details(self.task_id)
+            self.revision = task_data['payload']['env']['GECKO_HEAD_REV']
+        else:
+            self.task_id = taskcluster.get_task('mozilla-central', self.revision)
+
+        logger.info('Mercurial revision', revision=self.revision)
 
     def download_coverage_artifacts(self, build_task_id):
         try:
@@ -166,16 +176,10 @@ class CodeCov(object):
         run_check(['gecko-env', './mach', 'build-backend', '-b', 'ChromeMap'], cwd=self.repo_dir)
 
     def go(self):
-        task_id = taskcluster.get_last_task()
-
-        task_data = taskcluster.get_task_details(task_id)
-        revision = task_data['payload']['env']['GECKO_HEAD_REV']
-        logger.info('Mercurial revision', revision=revision)
-
-        self.download_coverage_artifacts(task_id)
+        self.download_coverage_artifacts(self.task_id)
         logger.info('Code coverage artifacts downloaded')
 
-        self.clone_mozilla_central(revision)
+        self.clone_mozilla_central(self.revision)
         logger.info('mozilla-central cloned')
         self.build_files()
         logger.info('Build successful')
@@ -183,7 +187,7 @@ class CodeCov(object):
         self.rewrite_jsvm_lcov()
         logger.info('JSVM LCOV files rewritten')
 
-        commit_sha = self.get_github_commit(revision)
+        commit_sha = self.get_github_commit(self.revision)
         logger.info('GitHub revision', revision=commit_sha)
 
         coveralls_jobs = []


### PR DESCRIPTION
Fixes #442.