### PR TITLE
[WIP] shipit_signoff: use postgresql's JSON data type

### DIFF
--- a/src/shipit_signoff/shipit_signoff/api.py
+++ b/src/shipit_signoff/shipit_signoff/api.py
@@ -5,8 +5,6 @@
 
 from __future__ import absolute_import
 
-import pickle
-
 from flask import abort, request, g, redirect
 import urllib.parse
 from sqlalchemy.orm.exc import NoResultFound
@@ -129,7 +127,7 @@ def create_step(uid):
 
     step.uid = uid
     step.state = 'running'
-    step.policy = pickle.dumps(request.json['policy'])
+    step.policy = request.json['policy']
 
     db.session.add(step)
 

--- a/src/shipit_signoff/shipit_signoff/models.py
+++ b/src/shipit_signoff/shipit_signoff/models.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 import datetime
-import pickle
+import json
 import enum
 
 import sqlalchemy as sa
@@ -36,14 +36,14 @@ class SignoffStep(db.Model):
     status_message = sa.Column(sa.String(200), nullable=True)
     created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
     completed = sa.Column(sa.DateTime, nullable=True)
-    policy = sa.Column(sa.Binary())
+    policy = sa.Column(sa.JSON)
     signatures = db.relationship('Signature')
 
     @property
     def policy_data(self):
         if not self.policy:
             return None
-        return pickle.loads(self.policy)
+        return json.loads(self.policy)
 
     def delete(self):
         '''


### PR DESCRIPTION
Move away from `pickle` to just storing the data structure as `json` in the database using postgresql's native `JSON` store. 

Allows the database to be human-readable, and makes cross-language use of the policy an option.