### PR TITLE
shipit_static_analysis: Disable 'modernize-use-auto' clang-tidy checker.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -105,7 +105,7 @@ class Workflow(object):
             '-*',
             'clang-analyzer-deadcode.DeadStores',
             'modernize-loop-convert',
-            'modernize-use-auto',
+            # 'modernize-use-auto', (controversial, see bug 1371052)
             'modernize-use-default',
             'modernize-raw-string-literal',
             # 'modernize-use-bool-literals', (too noisy because of `while (0)` in many macros)


### PR DESCRIPTION
Because using it systematically is controversial: https://bugzilla.mozilla.org/show_bug.cgi?id=1371052