### PR TITLE
shipit_signoff: Parse scheduled change information correctly.

### DIFF
--- a/src/shipit_signoff/shipit_signoff/balrog.py
+++ b/src/shipit_signoff/shipit_signoff/balrog.py
@@ -31,10 +31,9 @@ def make_signoffs_uri(policy_definition):
 def get_signoff_status(policy_definition):
     # TODO: switch this to a GET to /scheduled_changes/{object}/{sc_id} when that endpoint exists
     scheduled_changes = requests.get(
-        '{}/scheduled_changes/{}/{}'.format(app.config['BALROG_API_ROOT'],
-                                            policy_definition['object'],
-                                            policy_definition['sc_id'])
-    )
+        '{}/scheduled_changes/{}?all=1'.format(app.config['BALROG_API_ROOT'],
+                                               policy_definition['object'])
+    ).json().get('scheduled_changes', {})
     for sc in scheduled_changes:
         if sc['sc_id'] == policy_definition['sc_id']:
             return sc['signoffs'], sc['required_signoffs']


### PR DESCRIPTION
Found this bug after testing against a local Balrog instance. We need to grab info from the correct endpoint, and parse it correctly! With this fixed, I was able to simulate an end to end Balrog signoff, with:

Creating the step:
```
➜  shipit_signoff git:(local-auth) ✗ curl -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Bearer releng1' -d '{"parameters": {},
  "policy": {
    "method": "balrog",
    "definition":
      {"sc_id": 2, "object": "rules"}

  },
  "uid": "2"
 }' 'http://localhost:5000/step/2'
{}
```

...which ended up making a request to /api/scheduled_changes/rules?all=1 on Balrog.

Then:
```
➜  shipit_signoff git:(local-auth) ✗ curl -X GET --header 'Accept: application/json' --header 'Authorization: Bearer releng1' 'http://localhost:5000/step/2/status'
{
  "created": "2017-06-30 14:20:50.990759",
  "message": "None",
  "state": "running",
  "uid": "2"
}
```

...which made the same request.

Finally, I made the necessary signoff in Balrog, and did:
```
➜  shipit_signoff git:(local-auth) ✗ curl -X GET --header 'Accept: application/json' --header 'Authorization: Bearer releng1' 'http://localhost:5000/step/2/status'
{
  "created": "2017-06-30 14:44:17.301940",
  "message": "None",
  "state": "completed",
  "uid": "2"
}
```

...which correctly marked the Signoff Step as completed.