### PR TITLE
shipit_code_coverage: Use ssh-add to add the deploy key

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -77,8 +77,9 @@ class CodeCov(object):
         self.suites.sort()
 
     def update_github_repo(self):
-        with open(os.path.expanduser('~/.ssh/id_rsa'), 'w') as f:
+        with open('id_rsa', 'w') as f:
             f.write(self.deploy_key)
+        run_check(['ssh-add', 'id_rsa'])
 
         repo_path = os.path.join(self.cache_root, 'gecko-dev')
         if not os.path.isdir(repo_path):


### PR DESCRIPTION
I'm hoping this will fix #481.

`ssh-add` was asking me for a passphrase even though the key doesn't have any, but I've tested again today and it isn't anymore. I'm not sure what was wrong yesterday, but I'm pretty sure not asking for a passphrase is what it is supposed to do.