### PR TITLE
shipit_code_coverage: Directly parse grcov results from test machines instead of re-parsing the gcno/gcda files

### DIFF
--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -15,14 +15,14 @@ let
 
   # Marco grcov
   grcov = rustPlatform.buildRustPackage rec {
-    version = "0.1.21";
+    version = "0.1.24";
     name = "grcov-${version}";
 
     src = releng_pkgs.pkgs.fetchFromGitHub {
       owner = "marco-c";
       repo = "grcov";
       rev = "v${version}";
-      sha256 = "1a7j8b5h1sxvxlbpbp1pg5jps1hvpb1v6p5d1dxikpp9v7pq6srv";
+      sha256 = "1gp2z9vqqyryjnbdmrlia8nggl3w48x5jg4lf9f7ram8pwr6dhl5";
     };
 
     # running 4 tests
@@ -46,7 +46,7 @@ let
     # error: test failed
     doCheck = false;
 
-    depsSha256 = "08chiifma5aj4lvvfpv37mhcdsy66fk0kx47bkv57g5fwvczfbh7";
+    depsSha256 = "1bqrl2d8lfvv8qim9pyn54rvcv68f7r07svbms4z286x6icrm55v";
 
     meta = with releng_pkgs.pkgs.stdenv.lib; {
       description = "grcov collects and aggregates code coverage information for multiple source files.";

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -52,11 +52,6 @@ class CodeCov(object):
 
         task_data = taskcluster.get_task_details(build_task_id)
 
-        artifacts = taskcluster.get_task_artifacts(build_task_id)
-        for artifact in artifacts:
-            if 'target.code-coverage-gcno.zip' in artifact['name']:
-                taskcluster.download_artifact(build_task_id, '', artifact)
-
         all_suites = set()
 
         tasks = taskcluster.get_tasks_in_group(task_data['taskGroupId'])
@@ -71,7 +66,7 @@ class CodeCov(object):
             test_task_id = test_task['status']['taskId']
             artifacts = taskcluster.get_task_artifacts(test_task_id)
             for artifact in artifacts:
-                if any(n in artifact['name'] for n in ['code-coverage-gcda.zip', 'code-coverage-jsvm.zip']):
+                if any(n in artifact['name'] for n in ['code-coverage-grcov.zip', 'code-coverage-jsvm.zip']):
                     taskcluster.download_artifact(test_task_id, suite_name, artifact)
 
         self.suites = list(all_suites)
@@ -136,12 +131,12 @@ class CodeCov(object):
         files = os.listdir('ccov-artifacts')
         ordered_files = []
         for fname in files:
-            if ('gcda' in fname or 'gcno' in fname) and not fname.endswith('.zip'):
+            if 'grcov' in fname and not fname.endswith('.zip'):
                 continue
             if 'jsvm' in fname and fname.endswith('.zip'):
                 continue
 
-            if 'gcno' in fname or suite is None or suite in fname:
+            if suite is None or suite in fname:
                 ordered_files.append('ccov-artifacts/' + fname)
 
         cmd = [


### PR DESCRIPTION
Fixes #433.