### PR TITLE
shipit_code_coverage: Set self.revision also when the revision is passed as a parameter

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -38,7 +38,8 @@ class CodeCov(object):
             task_data = taskcluster.get_task_details(self.task_id)
             self.revision = task_data['payload']['env']['GECKO_HEAD_REV']
         else:
-            self.task_id = taskcluster.get_task('mozilla-central', self.revision)
+            self.task_id = taskcluster.get_task('mozilla-central', revision)
+            self.revision = revision
 
         logger.info('Mercurial revision', revision=self.revision)
 


### PR DESCRIPTION
Stupid bug.