### PR TITLE
shipit_frontend: Remove bullets and padding from list of bugs in the coverage by directory report

### DIFF
--- a/src/shipit_frontend/src/App/CodeCoverage.elm
+++ b/src/shipit_frontend/src/App/CodeCoverage.elm
@@ -231,7 +231,7 @@ viewDirectory ( path, directory ) =
                         ++ (toString diff)
                     )
                 ]
-            , td [] [ ul [] (List.map viewBug directory.bugs) ]
+            , td [] [ ul [ class "bug-list" ] (List.map viewBug directory.bugs) ]
             ]
 
 

--- a/src/shipit_frontend/src/scss/index.scss
+++ b/src/shipit_frontend/src/scss/index.scss
@@ -210,3 +210,8 @@ div.bugs {
     }
   }
 }
+
+.bug-list {
+  padding-left: 0;
+  list-style-type: none;
+}


### PR DESCRIPTION
Fixes #321.