### PR TITLE
shipit_static_analysis: Skip taskcluster proxy usage when loading artifacts through mach

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/clang.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang.py
@@ -57,6 +57,10 @@ class ClangTidy(object):
         self.work_dir = work_dir
         self.build_dir = os.path.join(work_dir, build_dir)
 
+        # Dirty hack to skip Taskcluster proxy usage when loading artifacts
+        if 'TASK_ID' in os.environ:
+            del os.environ['TASK_ID']
+
         # Check the local clang is available
         logger.info('Loading Mozilla clang-tidy...')
         run_check(CLANG_SETUP_CMD, cwd=work_dir)


### PR DESCRIPTION
Right now the shipit_static_analysis cannot run in Taskcluster tasks since it tries to load an artifact through mach and fails to solve the domain name used (http://taskcluster).
Mach [automatically detects that it's executed in a taskcluster task](https://hg.mozilla.org/mozilla-central/file/tip/taskcluster/taskgraph/optimize.py#l175) env by checking if `TASK_ID` environment variable is set. 
So this quick fix simply unsets in the Python env this variable...

@garbas The root cause seems to be a Nix issue. We already had to [hack the domain name resolution](https://github.com/mozilla-releng/services/blob/master/lib/cli_common/cli_common/taskcluster.py#L64) for taskcluster proxy for our own api clients.
This network resolution issue may also be the root cause of #401, i'd like to have your input on this.