### PR TITLE
Heroku fix for mkPython based projects

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -79,10 +79,12 @@ PROJECTS = {
         'deploy_options': {
             #'staging': {
             #    'heroku_app': 'releng-staging-notification-policy',
+            #    'heroku_dyno_type': 'web',
             #    'url': 'https://policy.notification.staging.mozilla-releng.net',
             #},
             # 'production': {
             #    'heroku_app': 'releng-production-notification-policy',
+            #    'heroku_dyno_type': 'web',
             #    'url': 'https://policy.notification.mozilla-releng.net',
             # },
         },
@@ -103,10 +105,12 @@ PROJECTS = {
         'deploy_options': {
             #'staging': {
             #    'heroku_app': 'releng-staging-notification-identity',
+            #    'heroku_dyno_type': 'web',
             #    'url': 'https://identity.notification.staging.mozilla-releng.net',
             #},
             # 'production': {
             #    'heroku_app': 'releng-production-notification-identity',
+            #    'heroku_dyno_type': 'web',
             #    'url': 'https://identity.notification.mozilla-releng.net',
             # },
         },
@@ -127,10 +131,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'releng-staging-archiver',
+                'heroku_dyno_type': 'web',
                 'url': 'https://archiver.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'releng-production-archiver',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://archiver.mozilla-releng.net',
             # },
         },
@@ -151,10 +157,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'releng-staging-clobberer',
+                'heroku_dyno_type': 'web',
                 'url': 'https://clobberer.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'releng-production-clobberer',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://clobberer.mozilla-releng.net',
             # },
         },
@@ -224,10 +232,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'releng-staging-mapper',
+                'heroku_dyno_type': 'web',
                 'url': 'https://mapper.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'releng-production-mapper',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://mapper.mozilla-releng.net',
             # },
         },
@@ -248,10 +258,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'releng-staging-tooltool',
+                'heroku_dyno_type': 'web',
                 'url': 'https://tooltool.staging.mozilla-releng.net',
             },
             'production': {
                 'heroku_app': 'releng-production-tooltool',
+                'heroku_dyno_type': 'web',
                 'url': 'https://tooltool.mozilla-releng.net',
             },
         },
@@ -272,10 +284,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'releng-staging-treestatus',
+                'heroku_dyno_type': 'web',
                 'url': 'https://treestatus.staging.mozilla-releng.net',
             },
             'production': {
                 'heroku_app': 'releng-production-treestatus',
+                'heroku_dyno_type': 'web',
                 'url': 'https://treestatus.mozilla-releng.net',
             },
         },
@@ -355,10 +369,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'shipit-staging-pipeline',
+                'heroku_dyno_type': 'web',
                 'url': 'https://pipeline.shipit.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'shipit-production-pipeline',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://pipeline.shipit.mozilla-releng.net',
             # },
         },
@@ -377,6 +393,7 @@ PROJECTS = {
             },
             # 'production': {
             #     'heroku_app': 'shipit-production-pulse-listener',
+            #     'heroku_dyno_type': 'worker',
             # },
         },
     },
@@ -411,10 +428,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'shipit-staging-signoff',
+                'heroku_dyno_type': 'web',
                 'url': 'https://signoff.shipit.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'shipit-production-signoff',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://signoff.shipit.mozilla-releng.net',
             # },
         },
@@ -446,10 +465,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'shipit-staging-taskcluster',
+                'heroku_dyno_type': 'web',
                 'url': 'https://taskcluster.shipit.staging.mozilla-releng.net',
             },
             # 'production': {
             #     'heroku_app': 'shipit-production-taskcluster',
+            #     'heroku_dyno_type': 'web',
             #     'url': 'https://taskcluster.shipit.mozilla-releng.net',
             # },
         },
@@ -470,10 +491,12 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'shipit-staging-uplift',
+                'heroku_dyno_type': 'web',
                 'url': 'https://uplift.shipit.staging.mozilla-releng.net',
             },
             'production': {
                 'heroku_app': 'shipit-production-uplift',
+                'heroku_dyno_type': 'web',
                 'url': 'https://uplift.shipit.mozilla-releng.net',
             },
         },

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -373,6 +373,7 @@ PROJECTS = {
         'deploy_options': {
             'staging': {
                 'heroku_app': 'shipit-staging-pulse-listener',
+                'heroku_dyno_type': 'worker',
             },
             # 'production': {
             #     'heroku_app': 'shipit-production-pulse-listener',

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -122,7 +122,7 @@ def get_deploy_task(index,
             'tools', 'deploy:HEROKU',
             project,
             '--heroku-app=' + deploy_options['heroku_app'],
-            '--heroku-dyno-type=' + deploy_options.get('heroku_dyno_type', 'web'),
+            '--heroku-dyno-type=' + deploy_options['heroku_dyno_type'],
             '--taskcluster-secret=repo:github.com/mozilla-releng/services:branch:' + channel,
             '--no-interactive',
         ] + extra_attributes

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -122,6 +122,7 @@ def get_deploy_task(index,
             'tools', 'deploy:HEROKU',
             project,
             '--heroku-app=' + deploy_options['heroku_app'],
+            '--heroku-dyno-type=' + deploy_options.get('heroku_dyno_type', 'web'),
             '--taskcluster-secret=repo:github.com/mozilla-releng/services:branch:' + channel,
             '--no-interactive',
         ] + extra_attributes

--- a/lib/please_cli/please_cli/deploy.py
+++ b/lib/please_cli/please_cli/deploy.py
@@ -206,6 +206,12 @@ def cmd_S3(ctx,
     required=False,
     )
 @click.option(
+    '--heroku-dyno-type',
+    required=False,
+    type=click.Choice(['web', 'worker']),
+    default='web'
+    )
+@click.option(
     '--extra-attribute',
     multiple=True,
     )
@@ -231,6 +237,7 @@ def cmd_HEROKU(ctx,
                heroku_app,
                heroku_username,
                heroku_api_token,
+               heroku_dyno_type,
                extra_attribute,
                nix_build,
                nix_push,
@@ -278,7 +285,7 @@ def cmd_HEROKU(ctx,
             "https://registry.heroku.com",
             heroku_username,
             heroku_api_token,
-            heroku_app + "/web",
+            heroku_app + "/" + heroku_dyno_type,
             "latest",
         )
     please_cli.utils.check_result(

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -745,6 +745,9 @@ in rec {
           done
           find $out -type d -name "__pycache__" -exec 'rm -r "{}"' \;
           find $out -type d -name "*.py" -exec '${python.__old.python.executable} -m compileall -f "{}"' \;
+
+          mkdir -p $out/etc
+          echo "${name}-${version}" > $out/etc/mozilla-releng-services
         '' + postInstall;
 
         shellHook = ''


### PR DESCRIPTION
This allows `shipit-pulse-listener` to run on an Heroku worker dyno:

 * supports Heroku worker dyno deployment
 * build /etc with a file so that network is running fine in Heroku (weird bug)

Fixes #401 & #512 