### PR TITLE
shipit_static_analysis: Configure gecko build with --enable-clang-plugin to fix many false positives.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -97,7 +97,7 @@ class Workflow(object):
 
         # mach configure
         logger.info('Mach configure...')
-        run_check(['gecko-env', './mach', 'configure'], cwd=self.repo_dir)
+        run_check(['gecko-env', './mach', 'configure', '--enable-clang-plugin'], cwd=self.repo_dir)
 
         # Build CompileDB backend
         logger.info('Mach build backend...')


### PR DESCRIPTION
We noticed many false positives on `MOZ_IMPLICIT` macros, and realized that `MOZ_CLANG_PLUGIN` was not defined (causing the `mozilla-*` checkers to complain about many macros that were accidentally configured for release builds).

Adding the `./mach configure` parameter `--enable-clang-plugin` fixed these issues for me locally.