### PR TITLE
shipit_uplift: Don't use reports associated with commits where codecov.io thinks the CI failed 

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
@@ -59,10 +59,10 @@ def get_coverage_builds():
         previous_commit = builds[1]['commit_sha']
     elif COVERAGE_SERVICE == CoverageService.CODECOV:
         r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev')
-        commits = r.json()['commits']
+        commit = r.json()['commit']
 
-        latest_commit = commits[0]['commitid']
-        previous_commit = commits[1]['commitid']
+        latest_commit = commit['commitid']
+        previous_commit = commit['parent']
 
     return (latest_commit, previous_commit)
 


### PR DESCRIPTION
Fixes #529 .

Codecov.io is considering **2bc71dbfe39fb68a827b26ec9f0387dfdf6a6030** to be associated with failing CI, its previous (**1b05f8ad37c2b68fdf3ac3dc1265939dce84587e**) with failing CI, then **0c215343b047edda15e96a28ef889afa3d4ecc02** with successful CI (see https://codecov.io/gh/marco-c/gecko-dev).

It is returning wrong information for "1b05f8ad37c2b68fdf3ac3dc1265939dce84587e", probably because of the failing CI thing (even though the CI didn't fail, I'm not sure yet why codecov thinks it did).

From the API's response (https://codecov.io/api/gh/marco-c/gecko-dev), instead of using `commits[0]['commitid']` as the latest and `commits[1]['commitid']` as the previous, we can use `commit['commitid']` as the latest and `commit['parent']` as the previous, as the 'parent' skips commits with failing CI.