### PR TITLE
shipit_code_coverage: Parallelize shipit-code-coverage task more

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -51,13 +51,15 @@ def download_artifact(task_id, suite, artifact):
     artifact_path = 'ccov-artifacts/' + task_id + '_' + suite + '_' + os.path.basename(artifact['name'])
 
     if os.path.exists(artifact_path):
-        return
+        return artifact_path
 
     r = requests.get(queue_base + 'task/' + task_id + '/artifacts/' + artifact['name'], stream=True)
 
     with open(artifact_path, 'wb') as f:
         r.raw.decode_content = True
         shutil.copyfileobj(r.raw, f)
+
+    return artifact_path
 
 
 def is_coverage_task(task):

--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 
 def wait_until(operation, timeout=30):
@@ -12,3 +13,19 @@ def wait_until(operation, timeout=30):
         elapsed += 1
 
     return None
+
+
+class ThreadPoolExecutorResult(ThreadPoolExecutor):
+    def __init__(self, *args, **kwargs):
+        self.futures = []
+        super(ThreadPoolExecutorResult, self).__init__(*args, **kwargs)
+
+    def submit(self, *args, **kwargs):
+        future = super(ThreadPoolExecutorResult, self).submit(*args, **kwargs)
+        self.futures.append(future)
+        return future
+
+    def __exit__(self, *args):
+        for future in self.futures:
+            future.result()
+        return super(ThreadPoolExecutorResult, self).__exit__(*args)


### PR DESCRIPTION
The changes in this PR make the download of coverage artifacts happen in parallel with the cloning/ building of mozilla-central and with the rewriting of JSVM artifacts.
The uploads to coveralls and codecov are parallelized too.

I expect most of the speedup will come from the parallelization of the download of coverage artifacts (a I/O-bound operation with basically almost 0% CPU utilization that takes around 15 minutes in total) with the rewriting of the JSVM artifacts (a CPU-bound operation).