### PR TITLE
shipit_code_coverage: Don't fail the task when pushing to GitHub fails

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -15,6 +15,17 @@ def wait_until(operation, timeout=30):
     return None
 
 
+def retry(operation, retries=3):
+    successful = False
+    while not successful and retries > 0:
+        try:
+            operation()
+            successful = True
+        except:
+            retries -= 1
+    return successful
+
+
 class ThreadPoolExecutorResult(ThreadPoolExecutor):
     def __init__(self, *args, **kwargs):
         self.futures = []


### PR DESCRIPTION
```
cli_common.command: Command failed with code: 128 (output=b'' command='git clone https://github.com/marco-c/gecko-dev' error=b"Cloning into 'gecko-dev'...\nerror: RPC failed; curl 56 OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110\nfatal: The remote end hung up unexpectedly\nfatal: early EOF\nfatal: index-pack failed\n")
Error: Command (`git clone https://github.com/marco-c/gecko-dev`) failed with code: 128.
```

Updating the GitHub repository periodically fails, so let's ignore failures here.