### PR TITLE
[releng_notification*] Notification create method 

### DIFF
--- a/lib/backend_common/backend_common/notifications.py
+++ b/lib/backend_common/backend_common/notifications.py
@@ -52,7 +52,6 @@ def create_new_nagbot_message(message: str, short_message: str, deadline: dateti
     '''
     Instantiates a new message to be sent repeatedly by NagBot
 
-    :param api_endpoint: HTTP endpoint of policy service
     :param message: Long description of message (ie email body)
     :param short_message: Short description of message (ie email subject, IRC message)
     :param deadline: Message expiry date
@@ -67,7 +66,7 @@ def create_new_nagbot_message(message: str, short_message: str, deadline: dateti
     if uid is None:
         uid = generate_random_uid()
 
-    request_url = current_app.config.get('RELENG_NOTIFICATION_IDENTITY_ENDPOINT') + '/message/' + uid
+    request_url = current_app.config.get('RELENG_NOTIFICATION_POLICY_ENDPOINT') + '/message/' + uid
 
     message_body = json.dumps({
         'deadline': deadline.isoformat(),

--- a/lib/backend_common/backend_common/notifications.py
+++ b/lib/backend_common/backend_common/notifications.py
@@ -4,15 +4,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
-from typing import List
-from datetime import datetime
-from requests import put
-from flask import current_app
-import mohawk
+
+import json
+import os
 import random
 import string
-import os
-import json
+from datetime import datetime
+from typing import List
+
+from requests import put
+
+import mohawk
+from flask import current_app
 
 '''
 Common constants and utilities for releng_notification_* services
@@ -84,7 +87,7 @@ def schedule_nagbot_message(message: str, short_message: str, deadline: datetime
     }
 
     # Support dev ssl ca cert
-    ssl_dev_ca = os.environ.get('SSL_DEV_CA')
+    ssl_dev_ca = current_app.config.get('SSL_DEV_CA')
     if ssl_dev_ca is not None:
         assert os.path.isdir(ssl_dev_ca), 'SSL_DEV_CA must be a dir with hashed dev ca certs'
 

--- a/lib/backend_common/backend_common/notifications.py
+++ b/lib/backend_common/backend_common/notifications.py
@@ -30,8 +30,8 @@ URGENCY_LEVELS = [
 
 def get_current_app_credentials() -> dict:
     return {
-        'id': current_app.config.get('TASKCLUSTER_CLIENT_ID'),
-        'key': current_app.config.get('TASKCLUSTER_ACCESS_TOKEN'),
+        'id': current_app.config['TASKCLUSTER_CLIENT_ID'],
+        'key': current_app.config['TASKCLUSTER_ACCESS_TOKEN'],
         'algorithm': 'sha256',
     }
 
@@ -48,7 +48,7 @@ def verify_policy_structure(policy: dict) -> None:
         raise KeyError('Policy frequency missing required key')
 
 
-def create_new_nagbot_message(message: str, short_message: str, deadline: datetime, policies: List[dict], uid: str=None) -> str:
+def schedule_nagbot_message(message: str, short_message: str, deadline: datetime, policies: List[dict], uid: str=None) -> str:
     '''
     Instantiates a new message to be sent repeatedly by NagBot
 
@@ -66,7 +66,7 @@ def create_new_nagbot_message(message: str, short_message: str, deadline: dateti
     if uid is None:
         uid = generate_random_uid()
 
-    request_url = current_app.config.get('RELENG_NOTIFICATION_POLICY_ENDPOINT') + '/message/' + uid
+    request_url = current_app.config['RELENG_NOTIFICATION_POLICY_URL'] + '/message/' + uid
 
     message_body = json.dumps({
         'deadline': deadline.isoformat(),

--- a/lib/backend_common/backend_common/notifications.py
+++ b/lib/backend_common/backend_common/notifications.py
@@ -4,6 +4,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
+from typing import List
+from datetime import datetime
+from requests import put
+from flask import current_app
+import mohawk
+import random
+import string
+import os
+import json
 
 '''
 Common constants and utilities for releng_notification_* services
@@ -17,3 +26,70 @@ CHANNELS = [
 URGENCY_LEVELS = [
     'LOW', 'NORMAL', 'HIGH',
 ]
+
+
+def get_current_app_credentials() -> dict:
+    return {
+        'id': current_app.config.get('TASKCLUSTER_CLIENT_ID'),
+        'key': current_app.config.get('TASKCLUSTER_ACCESS_TOKEN'),
+        'algorithm': 'sha256',
+    }
+
+
+def generate_random_uid() -> str:
+    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
+
+
+def verify_policy_structure(policy: dict) -> None:
+    if any(key not in policy for key in ['frequency', 'identity', 'start_timestamp', 'stop_timestamp', 'urgency']):
+        raise KeyError('Policy missing required key')
+
+    if any(freq_key not in policy['frequency'] for freq_key in ['days', 'hours', 'minutes']):
+        raise KeyError('Policy frequency missing required key')
+
+
+def create_new_nagbot_message(message: str, short_message: str, deadline: datetime, policies: List[dict], uid: str=None) -> str:
+    '''
+    Instantiates a new message to be sent repeatedly by NagBot
+
+    :param api_endpoint: HTTP endpoint of policy service
+    :param message: Long description of message (ie email body)
+    :param short_message: Short description of message (ie email subject, IRC message)
+    :param deadline: Message expiry date
+    :param policies: Notification policies described in dict format
+    :param uid: Optionally specify tracking uid. A random uid will be generated if not given
+
+    :return: Tracking uid for the notification
+    '''
+    for policy in policies:
+        verify_policy_structure(policy)
+
+    if uid is None:
+        uid = generate_random_uid()
+
+    request_url = current_app.config.get('RELENG_NOTIFICATION_IDENTITY_ENDPOINT') + '/message/' + uid
+
+    message_body = json.dumps({
+        'deadline': deadline.isoformat(),
+        'message': message,
+        'shortMessage': short_message,
+        'policies': policies,
+    })
+
+    hawk = mohawk.Sender(get_current_app_credentials(), request_url, 'put',
+                         content=message_body, content_type='application/json')
+
+    headers = {
+        'Authorization': hawk.request_header,
+        'Content-Type': 'application/json',
+    }
+
+    # Support dev ssl ca cert
+    ssl_dev_ca = os.environ.get('SSL_DEV_CA')
+    if ssl_dev_ca is not None:
+        assert os.path.isdir(ssl_dev_ca), 'SSL_DEV_CA must be a dir with hashed dev ca certs'
+
+    response = put(request_url, headers=headers, data=message_body, verify=ssl_dev_ca)
+    response.raise_for_status()
+
+    return uid

--- a/src/releng_notification_policy/releng_notification_policy/api.py
+++ b/src/releng_notification_policy/releng_notification_policy/api.py
@@ -221,8 +221,8 @@ def post_tick_tock() -> dict:
         for policy, identity_preference_url in get_identity_url_for_actionable_policies(policies):
             try:
                 service_credentials = {
-                    'id': current_app.config.get('TASKCLUSTER_CLIENT_ID'),
-                    'key': current_app.config.get('TASKCLUSTER_ACCESS_TOKEN'),
+                    'id': current_app.config['TASKCLUSTER_CLIENT_ID'],
+                    'key': current_app.config['TASKCLUSTER_ACCESS_TOKEN'],
                     'algorithm': 'sha256',
                 }
 
@@ -231,7 +231,7 @@ def post_tick_tock() -> dict:
                                      content_type='application/json')
 
                 # Support dev ssl ca cert
-                ssl_dev_ca = os.environ.get('SSL_DEV_CA')
+                ssl_dev_ca = current_app.config.get('SSL_DEV_CA')
                 if ssl_dev_ca is not None:
                     assert os.path.isdir(ssl_dev_ca), \
                         'SSL_DEV_CA must be a dir with hashed dev ca certs'

--- a/src/releng_notification_policy/settings.py
+++ b/src/releng_notification_policy/settings.py
@@ -39,6 +39,7 @@ secrets = cli_common.taskcluster.get_secrets(
 
 locals().update(secrets)
 
+SSL_DEV_CA = os.getenv('SSL_DEV_CA')  # should be set in development environments
 SECRET_KEY = base64.b64decode(secrets['SECRET_KEY_BASE64'])
 RELENG_NOTIFICATION_IDENTITY_ENDPOINT = secrets.get('RELENG_NOTIFICATION_IDENTITY_ENDPOINT')
 if not RELENG_NOTIFICATION_IDENTITY_ENDPOINT:


### PR DESCRIPTION
Adds a method in backend_common for other services to create nagbot messages (pipeline, signoff etc).

Two thoughts:
1. I added a method to generate random UID, should I remove and just assume caller will always provide?
2. Should this be implemented as a backend_common extension?

Services using this will need three config variables:
- RELENG_NOTIFICATION_POLICY_ENDPOINT
- TASKCLUSTER_CLIENT_ID
- TASKCLUSTER_ACCESS_TOKEN
