### PR TITLE
shipit_code_coverage: Fix scope issue that caused rewrite_jsvm_lcov to be called with random artifacts

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -59,6 +59,9 @@ class CodeCov(object):
 
         all_suites = set()
 
+        def rewriting_task(path):
+            return lambda: self.rewrite_jsvm_lcov(path)
+
         tasks = taskcluster.get_tasks_in_group(task_data['taskGroupId'])
         test_tasks = [t for t in tasks if taskcluster.is_coverage_task(t)]
         with ThreadPoolExecutorResult() as executor:
@@ -77,7 +80,7 @@ class CodeCov(object):
 
                     artifact_path = taskcluster.download_artifact(test_task_id, suite_name, artifact)
                     if 'code-coverage-jsvm.zip' in artifact['name']:
-                        executor.submit(lambda: self.rewrite_jsvm_lcov(artifact_path))
+                        executor.submit(rewriting_task(artifact_path))
 
             self.suites = list(all_suites)
             self.suites.sort()


### PR DESCRIPTION
I'm seeing rewrite_jsvm_lcov being called with artifacts with which it shouldn't be called (e.g. artifacts whose name doesn't contain `code-coverage-jsvm.zip`). I think it's a scope issue.