### PR TITLE
Bug 691673 - give trychooser the option of triggering (or not) a PGO …

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -33,7 +33,7 @@
                 <label id="build_type-none"><input type="radio" name="build_type" value="none" CHECKED>None</label>
             </span>
             <p><label><input type="checkbox" class="artifact-build">Use artifact build</label>
-            <p>Looking for PGO builds? See <a href="https://wiki.mozilla.org/ReleaseEngineering/TryChooser#What_if_I_want_PGO_for_my_build">this page</a>.</p>
+            <p>Looking for PGO builds? Pick "Opt only" (or "Both") and select PGO platforms below</a>.</p>
 
             <h4>Platforms</h4>
             <div class='option-group' id='platforms' try-section='p'>
@@ -45,6 +45,9 @@
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="linux64">linux64</label>
+            </li>
+            <li>
+                <label><input type="checkbox" name="platform" value="linux64-pgo">linux64-pgo</label>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="linux64-asan">linux64-asan</label>
@@ -74,10 +77,16 @@
                 <label><input type="checkbox" name="platform" value="win32">win32</label>
             </li>
             <li>
+                <label><input type="checkbox" name="platform" value="win32-pgo">win32-pgo</label>
+            </li>
+            <li>
                 <label><input type="checkbox" name="platform" value="win32-st-an">win32 static analysis</label>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="win64">win64</label>
+            </li>
+            <li>
+                <label><input type="checkbox" name="platform" value="win64-pgo">win64-pgo</label>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="win64-st-an">win64 static analysis</label>


### PR DESCRIPTION
…build for platforms that support PGO

Like :catlee said in [bug 691673 comment 33](https://bugzilla.mozilla.org/show_bug.cgi?id=691673#c33), Taskcluster now supports the PGO syntax. We can make it visible on try-chooser.

For the record, there is no pgo on macosx, only on Linux 64, Win32/64.