### PR TITLE
releng_treestatus: format in query was used in old old v0 api

### DIFF
--- a/src/releng_treestatus/releng_treestatus/api.py
+++ b/src/releng_treestatus/releng_treestatus/api.py
@@ -99,7 +99,7 @@ def _update_tree_status(session, tree, status=None, reason=None, tags=[],
 
 
 @cache.memoize()
-def v0_get_tree(tree):
+def v0_get_tree(tree, format):
     t = current_app.db.session.query(Tree).get(tree)
     if not t:
         raise NotFound('No such tree')
@@ -232,7 +232,7 @@ def get_logs(tree, all=0):
     return dict(result=logs)
 
 
-def v0_get_trees():
+def v0_get_trees(format):
     return get_trees()
 
 

--- a/src/releng_treestatus/releng_treestatus/api.yml
+++ b/src/releng_treestatus/releng_treestatus/api.yml
@@ -256,6 +256,11 @@ paths:
       description: |
         Get the status of all trees in a format compatible with the old
         treestatus.
+      parameters:
+        - name: format
+          in: query
+          description: Format type (dummy to keep backwards compatibility)
+          type: string
       responses:
         200:
           description: Status
@@ -275,6 +280,10 @@ paths:
           in: path
           description: Tree name
           required: true
+          type: string
+        - name: format
+          in: query
+          description: Format type (dummy to keep backwards compatibility)
           type: string
       responses:
         200:


### PR DESCRIPTION
fixes MOZILLA-RELENG-SERVICES-8R1 and MOZILLA-RELENG-SERVICES-8R2 on sentry