### PR TITLE
[WIP] Add development auth option

### DIFF
--- a/lib/backend_common/backend_common/auth.py
+++ b/lib/backend_common/backend_common/auth.py
@@ -231,7 +231,7 @@ class Auth(object):
         return decorator
 
 
-is_dev_session = bool(os.getenv('DEVELOPMENT', False))
+IS_DEVELOPMENT_INSTANCE = bool(os.getenv('DEVELOPMENT', False))
 auth = Auth(
     anonymous_user=AnonymousUser,
 )
@@ -321,7 +321,7 @@ def is_relengapi_token(token_str):
 
 @auth.login_manager.request_loader
 def parse_header(request):
-    if is_dev_session:
+    if IS_DEVELOPMENT_INSTANCE:
         return DevelopmentUser()
 
     auth_header = request.headers.get('Authorization')

--- a/lib/backend_common/backend_common/auth.py
+++ b/lib/backend_common/backend_common/auth.py
@@ -233,7 +233,7 @@ class Auth(object):
 
 is_dev_session = bool(os.getenv('DEVELOPMENT', False))
 auth = Auth(
-    anonymous_user=DevelopmentUser if is_dev_session else AnonymousUser,
+    anonymous_user=AnonymousUser,
 )
 
 
@@ -321,6 +321,9 @@ def is_relengapi_token(token_str):
 
 @auth.login_manager.request_loader
 def parse_header(request):
+    if is_dev_session:
+        return DevelopmentUser()
+
     auth_header = request.headers.get('Authorization')
     if not auth_header:
         return

--- a/lib/backend_common/backend_common/auth0.py
+++ b/lib/backend_common/backend_common/auth0.py
@@ -20,10 +20,14 @@ import flask_oidc
 import functools
 import json
 import requests
+import os
 
 
 logger = cli_common.log.get_logger(__name__)
 auth0 = flask_oidc.OpenIDConnect()
+
+
+IS_DEVELOPMENT_INSTANCE = bool(os.getenv('DEVELOPMENT', False))
 
 
 def mozilla_accept_token(render_errors=True):
@@ -49,6 +53,12 @@ def mozilla_accept_token(render_errors=True):
     def wrapper(view_func):
         @functools.wraps(view_func)
         def decorated(*args, **kwargs):
+            if IS_DEVELOPMENT_INSTANCE:
+                # TODO: set flask.g with mocked userinfo and access_token
+                # flask.g.userinfo = json.loads(str(fake_userinfo, 'utf-8'))
+                # flask.g.access_token = fake_token
+                return view_func(*args, **kwargs)
+
             token = None
             if flask.request.headers.get('Authorization', '').startswith('Bearer'):
                 token = flask.request.headers['Authorization'].split(maxsplit=1)[


### PR DESCRIPTION
Fix for #212 

Adds a new user model ```DevelopmentUser``` that is granted all scopes. This can be turned on/off via an environment variable ```DEVELOPMENT``` (I'm not sure if there is a standard way to determine if the application is a dev/staging/prod instance). 

This has been tested for auth.py in releng-frontend, a new contributor would start the instance with the flag set and from the front end select the "Sign in manually" option in Taskcluster. Then give any data and the auth decorators will no longer block them.

As far as I can tell the auth0.py fix will work if we can mock some data in the userinfo and token fields. I'm not sure what that data looks like, though.