### PR TITLE
Bug 1384482 - Trychooser: Drop Android API-15 in favor of API-16

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -92,16 +92,10 @@
                 <label><input type="checkbox" name="platform" value="win64-st-an">win64 static analysis</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="android-api-15">android api 15+</label>
+                <label><input type="checkbox" name="platform" value="android-api-16">android api-16+</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="android-api-15-gradle">android api 15+ gradle</label>
-            </li>
-            <li>
-                <label><input type="checkbox" name="platform" value="android-api-15-gradle-dependencies">android api 15+ gradle deps</label>
-            </li>
-            <li>
-                <label><input type="checkbox" name="platform" value="android-api-15-frontend">android api 15+ frontend</label>
+                <label><input type="checkbox" name="platform" value="android-api-16-gradle">android api-16+ gradle</label>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="android-x86">android-x86 (Android 4.2)</label>


### PR DESCRIPTION
Requires https://reviewboard.mozilla.org/r/166566/diff/ to land first, before being deployed.