### PR TITLE
Ensure all logging uses cli_common utility

### DIFF
--- a/src/releng_treestatus/releng_treestatus/api.py
+++ b/src/releng_treestatus/releng_treestatus/api.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 
 import datetime
 import json
-import logging
 import pytz
 import sqlalchemy as sa
 
@@ -15,6 +14,7 @@ from flask import current_app
 from flask_login import current_user
 from werkzeug.exceptions import NotFound, BadRequest
 
+import cli_common.log
 from backend_common.cache import cache
 from backend_common.auth import auth
 from releng_treestatus.models import (
@@ -25,7 +25,7 @@ from releng_treestatus.models import (
 UNSET = object()
 TREE_SUMMARY_LOG_LIMIT = 5
 
-log = logging.getLogger(__name__)
+log = cli_common.log.get_logger(__name__)
 
 
 def _get(item, field, default=UNSET):

--- a/src/shipit_pipeline/shipit_pipeline/api.py
+++ b/src/shipit_pipeline/shipit_pipeline/api.py
@@ -5,12 +5,12 @@
 
 from __future__ import absolute_import
 
-import logging
+import cli_common.log
 
 from shipit_pipeline.pipeline import get_runnable_steps, get_running_steps, refresh_pipeline_steps, start_steps,\
     PipelineStep
 
-log = logging.getLogger(__name__)
+log = cli_common.log.get_logger(__name__)
 
 PIPELINES = {}
 MockSteps = {}

--- a/src/shipit_static_analysis/shipit_static_analysis/cli.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/cli.py
@@ -12,10 +12,8 @@ from cli_common.click import taskcluster_options
 from cli_common.log import init_logger
 from cli_common.taskcluster import get_secrets
 import click
-import logging
 import re
 
-logger = logging.getLogger(__name__)
 
 REGEX_COMMIT = re.compile(r'(\w+):(\d+):(\d+)')
 

--- a/src/shipit_taskcluster/shipit_taskcluster/api.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/api.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import
 
-import logging
 import datetime
 
 from flask import abort
@@ -13,10 +12,11 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import IntegrityError
 
 from backend_common.db import db
+import cli_common.log
 from shipit_taskcluster.models import TaskclusterStatus, TaskclusterStep
 from shipit_taskcluster.taskcluster_utils import get_taskcluster_tasks_state
 
-log = logging.getLogger(__name__)
+log = cli_common.log.get_logger(__name__)
 
 
 # api

--- a/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
+++ b/src/shipit_taskcluster/shipit_taskcluster/taskcluster_utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import logging
 from collections import Counter
 
 import taskcluster
+import cli_common.log
 
-log = logging.getLogger(__name__)
+log = cli_common.log.get_logger(__name__)
 
 TC_QUEUE = taskcluster.Queue()
 TC_SCHEDULER = taskcluster.Scheduler()


### PR DESCRIPTION
Some of the logging is still being done by Python's ```logging``` module. This PR ensures all logging is done via the ```cli_common.log``` module.