### PR TITLE
releng_docs: Add mapper docs, update notification docs, fix incorrect command

### DIFF
--- a/src/releng_docs/develop/python-project.rst
+++ b/src/releng_docs/develop/python-project.rst
@@ -16,7 +16,7 @@ Python project
 
   Every time you add/remove/update dependencies rereun::
 
-      % ./please update-dependencies <project>
+      % ./please tools update-dependencies <project>
 
   More information about updating dependencies you can find here (TODO: link)
 

--- a/src/releng_docs/index.rst
+++ b/src/releng_docs/index.rst
@@ -30,6 +30,7 @@ Projects
 
     releng-docs <projects/releng-docs>
     releng-frontend <projects/releng-frontend>
+    releng-mapper <projects/releng-mapper>
     releng-notification-identity <projects/releng-notification-identity>
     releng-notification-policy <projects/releng-notification-policy>
     releng-tooltool <projects/releng-tooltool>

--- a/src/releng_docs/projects/releng-mapper.rst
+++ b/src/releng_docs/projects/releng-mapper.rst
@@ -1,0 +1,35 @@
+.. _releng-mapper-project:
+
+Project: releng-mapper
+======================
+
+:production: https://mapper.mozilla-releng.net
+:staging: https://mapper.staging.mozilla-releng.net
+:contact: `Rok Garbas`_, (backup `Release Engineering`_)
+
+When we convert hg repositories to git, and vice versa, the hg changeset SHA (the 40 character hexadecimal string that
+you get when you commit a change) is different to the git commit id (the equivalent SHA used by git).
+
+In order to keep track of which hg changeset SHAs relate to which git commit SHAs, we keep a database of the mappings,
+together with details about the project the SHAs come from, and what time they were inserted into the database.
+
+The vcs sync tool (checked into mozharness) is the tool which performs the conversion between hg repos and git repos,
+and this is documented separately. It is responsible for performing the conversion - this is outside the scope of mapper.
+
+Mapper is an HTTP API that allows:
+
+ *  insertion of new mappings and projects (a "project" is essentially the name of the repo - e.g. build-tools) (HTTP POST)
+ *  insertion of git/hg mappings for a given project (HTTP POST)
+ *  retrieval of mappings for a given project (HTTP GET)
+
+Behind the scenes, it is reading/writing from the database (using sqlalchemy).
+
+Note: the vcs sync tool is a client of the mapper: it is vcs sync that inserts into mapper (i.e. uses the HTTP POST methods).
+The other clients of mapper are:
+
+ *  people / developers - wanting to query mappings
+ *  ``b2g_build.py`` - the build script for b2g - since this needs to lookup SHAs in order to reference frozen commit versions in manifests
+
+
+.. _`Rok Garbas`: https://phonebook.mozilla.org/?search/Rok%20Garbas
+.. _`Release Engineering`: https://wiki.mozilla.org/ReleaseEngineering#Contacting_Release_Engineering

--- a/src/releng_docs/projects/releng-notification-identity.rst
+++ b/src/releng_docs/projects/releng-notification-identity.rst
@@ -7,14 +7,10 @@ Project: releng-notification-identity
 :staging: https://notification-identity.staging.mozilla-releng.net
 :contact: `Rok Garbas`_, (backup `Release Engineering`_)
 
-RelEng Notification Identity is a tool to store the notification preferences of
-different individuals and groups for different levels of urgency. Parties who
-will be notified of events related to the release cycle (human decisions,
-signoffs, chemspills etc) register their identity name, and specify how to
-notify based on different levels of urgency.  Currently *email* is the only
-supported notification channel, and *low, normal, high, do it yesterday* are
-the urgency levels. RelEng Notification Identity is meant to work together with
-RelEng Notification Policy.
+RelEng Notification Identity is a tool to store the notification preferences of parties involved in the release process.
+Parties who will be notified of events related to the release cycle (human decisions, signoffs, chemspills etc) register
+a name/identifier, and specify how to notify based on different levels of urgency.  Currently *email* and *irc* are the
+only supported notification channels, and *low, normal, high* are the urgency levels.
 
 .. _`Rok Garbas`: https://phonebook.mozilla.org/?search/Rok%20Garbas
 .. _`Release Engineering`: https://wiki.mozilla.org/ReleaseEngineering#Contacting_Release_Engineering

--- a/src/releng_docs/projects/releng-notification-policy.rst
+++ b/src/releng_docs/projects/releng-notification-policy.rst
@@ -7,12 +7,13 @@ Project: releng-notification-policy
 :staging: https://notification-policy.staging.mozilla-releng.net
 :contact: `Rok Garbas`_, (backup `Release Engineering`_)
 
-RelEng Notification Policy is a tool to send RelEng related notifications based
-on periodic policies, and escalate unacknowledged notifications to higher
-urgency levels. Message requests are sent to the service with details on who to
-notify and how urgent the message is. Policies for how to notify these
-stakeholders are retrieved from the RelEng Notification Identity service.
-
+RelEng Notification Policy is a tool to schedule notifications requiring an "escalation path". Message requests are
+sent to the service with the message contents and a list of "policies". Each policy contains a start and end time, a
+notification frequency, an urgency and an identity to notify (retrieved from the RelEng Notification Identity service).
+Escalation paths can be formed by increasing the urgency level of messages over time, increasing message urgency or
+sending messages to more individuals if the message is not acknowledged by a certain time. Notifications are triggered
+via a hook/ticktock endpoint. When the endpoint is triggered, the service will retrieve all unacknowledged messages
+and send notifications according to any policy with a valid start/end time.
 
 
 .. _`Rok Garbas`: https://phonebook.mozilla.org/?search/Rok%20Garbas


### PR DESCRIPTION
Update the notification docs, migrate docs from relengapi for the mapper, and fix an incorrect command in documentation (should be ```./please tools update-dependencies <project>```).