### PR TITLE
shipit_code_coverage: Use push ID as the Coveralls service number

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -145,6 +145,8 @@ class CodeCov(object):
             if suite is None or suite in fname:
                 ordered_files.append('ccov-artifacts/' + fname)
 
+        r = requests.get('https://hg.mozilla.org/mozilla-central/json-rev/%s' % self.revision)
+
         cmd = [
           'grcov',
           '-t', 'coveralls',
@@ -153,6 +155,7 @@ class CodeCov(object):
           '--ignore-dir', 'gcc',
           '--ignore-not-existing',
           '--service-name', 'TaskCluster',
+          '--service-number', str(r.json()['pushid'])
           '--commit-sha', commit_sha,
           '--token', coveralls_token,
         ]

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -146,6 +146,7 @@ class CodeCov(object):
                 ordered_files.append('ccov-artifacts/' + fname)
 
         r = requests.get('https://hg.mozilla.org/mozilla-central/json-rev/%s' % self.revision)
+        push_id = r.json()['pushid']
 
         cmd = [
           'grcov',
@@ -155,7 +156,7 @@ class CodeCov(object):
           '--ignore-dir', 'gcc',
           '--ignore-not-existing',
           '--service-name', 'TaskCluster',
-          '--service-number', str(r.json()['pushid'])
+          '--service-number', str(push_id),
           '--commit-sha', commit_sha,
           '--token', coveralls_token,
         ]


### PR DESCRIPTION
This way we can more easily identify builds on coveralls.io.