### PR TITLE
Don't fail if Bugzilla returns an empty result

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
@@ -157,7 +157,10 @@ def generate(path):
       'id': ','.join([str(b) for b in sorted(all_bugs)])
     })
 
-    for found_bug in r.json()['bugs']:
+    response = r.json()
+    found_bugs = response['bugs'] if 'bugs' in response else []
+
+    for found_bug in found_bugs:
         for directory in data.values():
             for bug in directory['bugs']:
                 if bug['id'] == found_bug['id']:


### PR DESCRIPTION
If there are no changes in a directory, there's no mercurial changeset associated with it and thus no bugs. The Bugzilla query returns an emtpy result.