### PR TITLE
Remove mochitest-jetpack suite from trychooser

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -241,7 +241,6 @@
                     <li><label><input type="checkbox" value="mochitest-a11y">mochitest-ally</label></li>
                     <li><label><input type="checkbox" value="mochitest-chrome">mochitest-chrome</label></li>
                     <li><label><input type="checkbox" value="mochitest-media">mochitest-mda (dom/media)</label></li>
-                    <li><label><input type="checkbox" value="mochitest-jetpack">mochitest-jetpack</label></li>
                     <li><label><input type="checkbox" value="mochitest-e10s-1">mochitest-e10s-1</label></li>
                     <li><label><input type="checkbox" value="mochitest-e10s-2">mochitest-e10s-2</label></li>
                     <li><label><input type="checkbox" value="mochitest-e10s-3">mochitest-e10s-3</label></li>


### PR DESCRIPTION
The SDK and all of its accompanying tests are being removed from
mozilla-central in bug 1371065, after which this suite will no longer be
supported. In the mean time, it runs only one test, which no-one should have
any particular need to trigger.