### PR TITLE
shipit_uplift: Remove coverage info for removed lines (as it was unused)

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -5,7 +5,7 @@
 
 import requests
 import whatthepatch
-from shipit_uplift.coverage import coverage_service, get_coverage_builds
+from shipit_uplift.coverage import coverage_service, get_coverage_build
 
 
 def generate(changeset):
@@ -13,7 +13,7 @@ def generate(changeset):
     This function generates a report containing the coverage information of the diff
     introduced by a changeset.
     '''
-    previous_build_changeset, _, next_build_changeset, _ = get_coverage_builds(changeset)
+    build_changeset, _ = get_coverage_build(changeset)
 
     r = requests.get('https://hg.mozilla.org/mozilla-central/raw-rev/%s' % changeset)
     patch = r.text
@@ -22,47 +22,37 @@ def generate(changeset):
 
     for diff in whatthepatch.parse_patch(patch):
         # Get old and new path, for files that have been renamed.
-        old_path = diff.header.old_path[2:] if diff.header.old_path.startswith('a/') else diff.header.old_path
         new_path = diff.header.new_path[2:] if diff.header.new_path.startswith('b/') else diff.header.new_path
 
         # If the diff doesn't contain any changes, we skip it.
         if diff.changes is None:
             continue
 
-        # Retrieve coverage of removed and added lines.
-        new_coverage = coverage_service.get_file_coverage(next_build_changeset, new_path)
-        old_coverage = coverage_service.get_file_coverage(previous_build_changeset, old_path)
+        # Retrieve coverage of added lines.
+        coverage = coverage_service.get_file_coverage(build_changeset, new_path)
 
         # If we don't have coverage for this file, we skip it.
-        if old_coverage is None and new_coverage is None:
+        if coverage is None:
             continue
 
         changes = []
         for old_line, new_line, _ in diff.changes:
-            if old_line is not None and new_line is None:
-                # Removed line.
-                if old_line not in old_coverage or old_coverage[old_line] is None:
-                    coverage = '?'
-                elif old_coverage[old_line] > 0:
-                    coverage = 'Y'
-                else:
-                    coverage = 'N'
-            elif old_line is None and new_line is not None:
+            if old_line is None and new_line is not None:
                 # Added line.
-                if new_line not in new_coverage or new_coverage[new_line] is None:
+                if new_line not in coverage or coverage[new_line] is None:
                     # We have no coverage information for this line (e.g. a definition, like
                     # a variable in a header file).
-                    coverage = '?'
-                elif new_coverage[new_line] > 0:
-                    coverage = 'Y'
+                    covered = '?'
+                elif coverage[new_line] > 0:
+                    covered = 'Y'
                 else:
-                    coverage = 'N'
+                    covered = 'N'
             else:
-                # Unmodified line.
+                # Unmodified or removed line.
                 continue
 
             changes.append({
-                'coverage': coverage,
+                'coverage': covered,
                 'old_line': old_line,
                 'new_line': new_line,
             })
@@ -73,7 +63,6 @@ def generate(changeset):
         })
 
     return {
-        'build_changeset': next_build_changeset,
-        'previous_build_changeset': previous_build_changeset,
+        'build_changeset': build_changeset,
         'diffs': diffs,
     }

--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -13,7 +13,7 @@ def generate(changeset):
     This function generates a report containing the coverage information of the diff
     introduced by a changeset.
     '''
-    build_changeset, _ = get_coverage_build(changeset)
+    build_changeset, overall = get_coverage_build(changeset)
 
     r = requests.get('https://hg.mozilla.org/mozilla-central/raw-rev/%s' % changeset)
     patch = r.text
@@ -64,5 +64,7 @@ def generate(changeset):
 
     return {
         'build_changeset': build_changeset,
+        'overall_cur': overall['cur'],
+        'overall_prev': overall['prev'],
         'diffs': diffs,
     }

--- a/src/shipit_uplift/shipit_uplift/coverage_summary_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_summary_by_changeset_impl.py
@@ -5,7 +5,7 @@
 
 import requests
 import whatthepatch
-from shipit_uplift.coverage import coverage_service, get_coverage_builds
+from shipit_uplift.coverage import coverage_service, get_coverage_build
 
 
 def generate(changeset):
@@ -13,7 +13,7 @@ def generate(changeset):
     This function generates a summary of the overall coverage information for a changeset and
     of the diff introduced by a changeset.
     '''
-    _, _, next_build_changeset, overall = get_coverage_builds(changeset, before=False)
+    next_build_changeset, overall = get_coverage_build(changeset)
 
     r = requests.get('https://hg.mozilla.org/mozilla-central/raw-rev/%s' % changeset)
     patch = r.text


### PR DESCRIPTION
And add overall information to "/coverage/changeset" endpoint.