### PR TITLE
shipit_uplift: Don't fail requesting coverage info for a commit if we don't have info about the parent

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -107,7 +107,7 @@ class CodecovCoverage(Coverage):
 
         return {
           'cur': result['commit']['totals']['c'],
-          'prev': result['commit']['parent_totals']['c'],
+          'prev': result['commit']['parent_totals']['c'] if result['commit']['parent_totals'] else '?',
         }
 
     @staticmethod


### PR DESCRIPTION
Fixes #620.