### PR TITLE
shipit_uplift: Retrieve coverage information in parallel with multiple threads

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -5,12 +5,11 @@
 
 from abc import ABC, abstractmethod
 import json
+from functools import lru_cache
 import requests
 
-from backend_common.cache import cache
 
-
-@cache.memoize()
+@lru_cache(maxsize=128)
 def get_github_commit(mercurial_commit):
     r = requests.get('https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s' % mercurial_commit)
     return r.text.split(' ')[0]
@@ -42,7 +41,7 @@ class CoverallsCoverage(Coverage):
     URL = 'https://coveralls.io'
 
     @staticmethod
-    @cache.memoize()
+    @lru_cache(maxsize=32)
     def get_coverage(changeset):
         r = requests.get(CoverallsCoverage.URL + '/builds/%s.json' % get_github_commit(changeset))
 
@@ -57,7 +56,6 @@ class CoverallsCoverage(Coverage):
         }
 
     @staticmethod
-    @cache.memoize()
     def get_file_coverage(changeset, filename):
         r = requests.get(CoverallsCoverage.URL + '/builds/%s/source.json' % get_github_commit(changeset), params={
             'filename': filename,
@@ -76,7 +74,7 @@ class CoverallsCoverage(Coverage):
         return builds[0]['commit_sha'], builds[1]['commit_sha']
 
     @staticmethod
-    @cache.memoize()
+    @lru_cache(maxsize=32)
     def get_directory_coverage(changeset, prev_changeset, directory):
         r = requests.get(CoverallsCoverage.URL + '/builds/' + get_github_commit(changeset) + '.json?paths=' + directory + '/*')
 
@@ -96,7 +94,7 @@ class CodecovCoverage(Coverage):
     URL = 'https://codecov.io/api/gh/marco-c/gecko-dev'
 
     @staticmethod
-    @cache.memoize()
+    @lru_cache(maxsize=32)
     def get_coverage(changeset):
         r = requests.get(CodecovCoverage.URL + '/commit/%s' % get_github_commit(changeset))
 
@@ -111,7 +109,6 @@ class CodecovCoverage(Coverage):
         }
 
     @staticmethod
-    @cache.memoize()
     def get_file_coverage(changeset, filename):
         r = requests.get(CodecovCoverage.URL + '/src/%s/%s' % (get_github_commit(changeset), filename))
 
@@ -133,7 +130,7 @@ class CodecovCoverage(Coverage):
         return commit['commitid'], commit['parent']
 
     @staticmethod
-    @cache.memoize()
+    @lru_cache(maxsize=32)
     def get_directory_coverage(changeset, prev_changeset, directory):
         r = requests.get(CodecovCoverage.URL + '/tree/' + get_github_commit(changeset) + '/' + directory)
 
@@ -160,11 +157,11 @@ class ActiveDataCoverage(Coverage):
     URL = 'https://activedata.allizom.org/query'
 
     @staticmethod
+    @lru_cache(maxsize=32)
     def get_coverage(changeset):
         assert False, 'Not implemented'
 
     @staticmethod
-    @cache.memoize()
     def get_file_coverage(changeset, filename):
         r = requests.post(ActiveDataCoverage.URL, data=json.dumps({
             'from': 'coverage-summary',
@@ -199,6 +196,7 @@ class ActiveDataCoverage(Coverage):
         assert False, 'Not implemented'
 
     @staticmethod
+    @lru_cache(maxsize=32)
     def get_directory_coverage(changeset, prev_changeset, directory):
         assert False, 'Not implemented'
 


### PR DESCRIPTION
Fixes #609.

Unfortunately, there's an exception when I run this:
```
Traceback (most recent call last):
  File "/nix/store/5y3riwfpxx4hx17b5ww6pw16rv68vri8-python3.5-Flask-Cache-0.13.1/lib/python3.5/site-packages/flask_cache/__init__.py", line 528, in decorated_function
    cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
  File "/nix/store/5y3riwfpxx4hx17b5ww6pw16rv68vri8-python3.5-Flask-Cache-0.13.1/lib/python3.5/site-packages/flask_cache/__init__.py", line 381, in make_cache_key
    timeout=_timeout)
  File "/nix/store/5y3riwfpxx4hx17b5ww6pw16rv68vri8-python3.5-Flask-Cache-0.13.1/lib/python3.5/site-packages/flask_cache/__init__.py", line 350, in _memoize_version
    version_data_list = list(self.cache.get_many(*fetch_keys))
  File "/nix/store/5y3riwfpxx4hx17b5ww6pw16rv68vri8-python3.5-Flask-Cache-0.13.1/lib/python3.5/site-packages/flask_cache/__init__.py", line 192, in cache
    return app.extensions['cache'][self]
  File "/nix/store/r4gpw8pansyhv8s8my5a63h4rqk5216n-python3.5-Werkzeug-0.12.2/lib/python3.5/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/nix/store/r4gpw8pansyhv8s8my5a63h4rqk5216n-python3.5-Werkzeug-0.12.2/lib/python3.5/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/globals.py", line 51, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
to interface with the current application object in a way.  To solve
this set up an application context with app.app_context().  See the
documentation for more information.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/nix/store/lhxidxmmjqv42b706xyvw4bvx9q8y581-python3.5-python3.5-gunicorn-19.7.1/lib/python3.5/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/nix/store/lhxidxmmjqv42b706xyvw4bvx9q8y581-python3.5-python3.5-gunicorn-19.7.1/lib/python3.5/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1985, in wsgi_app
    response = self.handle_exception(e)
  File "/nix/store/cphhvwijx9j0amib71zi0xc810riqa25-python3.5-Flask-Cors-3.0.3/lib/python3.5/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1540, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/nix/store/cphhvwijx9j0amib71zi0xc810riqa25-python3.5-Flask-Cors-3.0.3/lib/python3.5/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/nix/store/mxdpcimf56ak903wfvy72vs3h2m5yp7a-python3.5-python3.5-connexion-1.1.14/lib/python3.5/site-packages/connexion/decorators/decorator.py", line 66, in wrapper
    response = function(request)
  File "/nix/store/mxdpcimf56ak903wfvy72vs3h2m5yp7a-python3.5-python3.5-connexion-1.1.14/lib/python3.5/site-packages/connexion/decorators/validation.py", line 293, in wrapper
    return function(request)
  File "/nix/store/mxdpcimf56ak903wfvy72vs3h2m5yp7a-python3.5-python3.5-connexion-1.1.14/lib/python3.5/site-packages/connexion/decorators/response.py", line 85, in wrapper
    response = function(request)
  File "/nix/store/mxdpcimf56ak903wfvy72vs3h2m5yp7a-python3.5-python3.5-connexion-1.1.14/lib/python3.5/site-packages/connexion/decorators/decorator.py", line 42, in wrapper
    response = function(request)
  File "/nix/store/mxdpcimf56ak903wfvy72vs3h2m5yp7a-python3.5-python3.5-connexion-1.1.14/lib/python3.5/site-packages/connexion/decorators/parameter.py", line 201, in wrapper
    return function(**kwargs)
  File "/home/marco/Documenti/workspace/mozilla-releng-services/src/shipit_uplift/shipit_uplift/api.py", line 385, in coverage_by_changeset
    return coverage_by_changeset_impl.generate(changeset)
  File "/home/marco/Documenti/workspace/mozilla-releng-services/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py", line 76, in generate
    res = future.result()
  File "/nix/store/4h6i7al6skhnpa3z3dbgbyd38b04zgbp-python3-3.5.3/lib/python3.5/concurrent/futures/_base.py", line 398, in result
    return self.__get_result()
  File "/nix/store/4h6i7al6skhnpa3z3dbgbyd38b04zgbp-python3-3.5.3/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/nix/store/4h6i7al6skhnpa3z3dbgbyd38b04zgbp-python3-3.5.3/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/marco/Documenti/workspace/mozilla-releng-services/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py", line 74, in <lambda>
    futures.append(executor.submit(lambda: parse_diff(diff)))
  File "/home/marco/Documenti/workspace/mozilla-releng-services/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py", line 39, in parse_diff
    coverage = coverage_service.get_file_coverage(build_changeset, new_path)
  File "/nix/store/5y3riwfpxx4hx17b5ww6pw16rv68vri8-python3.5-Flask-Cache-0.13.1/lib/python3.5/site-packages/flask_cache/__init__.py", line 531, in decorated_function
    if current_app.debug:
  File "/nix/store/r4gpw8pansyhv8s8my5a63h4rqk5216n-python3.5-Werkzeug-0.12.2/lib/python3.5/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/nix/store/r4gpw8pansyhv8s8my5a63h4rqk5216n-python3.5-Werkzeug-0.12.2/lib/python3.5/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/nix/store/qv8yhf6aardpn725f3vlrv5fxi3s806g-python3.5-Flask-0.12.2/lib/python3.5/site-packages/flask/globals.py", line 51, in _find_app
    raise RuntimeError(_app_ctx_err_msg)
RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
to interface with the current application object in a way.  To solve
this set up an application context with app.app_context().  See the
documentation for more information.
```