### PR TITLE
shipit_code_coverage: Wait for the build to be ingested by the coverage service and request the backend to generate and cache the data for all changesets in the push

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -250,12 +250,9 @@ class CodeCov(object):
 
             # Get pushlog and ask the backend to generate the coverage by changeset
             # data, which will be cached.
-            r = requests.get('https://hg.mozilla.org/mozilla-central/json-rev/%s' % self.revision)
-            push_id = int(r.json()['pushid'])
-
-            r = requests.get('https://hg.mozilla.org/mozilla-central/json-pushes?startID=%s&endID=%s' % (push_id - 1, push_id))
+            r = requests.get('https://hg.mozilla.org/mozilla-central/json-pushes?changeset=%s&version=2' % self.revision)
             data = r.json()
-            changesets = data[str(push_id)]['changesets']
+            changesets = data['pushes'][data['lastpushid']]['changesets']
 
             for changeset in changesets:
                 requests.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/changeset/%s' % changeset)

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -239,12 +239,12 @@ class CodeCov(object):
             executor.submit(lambda: uploader.coveralls(output))
             executor.submit(lambda: uploader.codecov(output, commit_sha, self.codecov_token))
 
-        logger.info('Waiting for build to be injested by Codecov...')
-        # Wait until the build has been injested by Codecov.
+        logger.info('Waiting for build to be ingested by Codecov...')
+        # Wait until the build has been ingested by Codecov.
         if uploader.codecov_wait(commit_sha):
-            logger.info('Build injested by codecov.io')
+            logger.info('Build ingested by codecov.io')
         else:
-            logger.info('codecov.io took too much time to injest data.')
+            logger.info('codecov.io took too much time to ingest data.')
 
         # Get pushlog and ask the backend to generate the coverage by changeset
         # data, which will be cached.

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -3,6 +3,7 @@ import gzip
 import requests
 
 from cli_common.log import get_logger
+from shipit_code_coverage import utils
 
 
 logger = get_logger(__name__)
@@ -57,3 +58,11 @@ def codecov(data, commit_sha, token, flags=None):
 
     if r.status_code != requests.codes.ok:
         raise Exception('Failure to upload data to S3. Response [%s]: %s' % (r.status_code, r.text))
+
+
+def codecov_wait(commit):
+    def check_codecov_job():
+        r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev/commit/%s' % commit)
+        return True if r.json()['commit']['totals'] is not None else False
+
+    return utils.wait_until(check_codecov_job, 30) is not None


### PR DESCRIPTION
Fixes #615.