### PR TITLE
Set WEB_CONCURRENCY env variable by default to 3

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -531,6 +531,7 @@ in rec {
     , passthru ? {}
     , inStaging ? true
     , inProduction ? false
+    , gunicornWorkers ? 3
     }:
     let
       self = mkPython (args // {
@@ -589,6 +590,7 @@ in rec {
         dockerEnv = [
           "APP_SETTINGS=${self}/etc/settings.py"
           "FLASK_APP=${dirname}.flask:app"
+          "WEB_CONCURRENCY=${gunicornWorkers}"
         ];
         dockerCmd = [
           "gunicorn"


### PR DESCRIPTION
Fixes #643.

We are not setting this environment variable by default, which means we end up with a single gunicorn worker. Heroku suggests setting it to 2 or 3 for `free`, `hobby` and `standard-1x` dynos