### PR TITLE
shipit_uplift: Add more extensions to the supported list

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -244,9 +244,9 @@ def coverage_supported(path):
         # C
         'c', 'h',
         # C++
-        'cpp', 'hh', 'hpp',
+        'cpp', 'cc', 'cxx', 'hh', 'hpp', 'hxx',
         # JavaScript
-        'js', 'jsm',
+        'js', 'jsm', 'xul', 'xml', 'html', 'xhtml',
     ]
 
     return any([path.endswith('.' + ext) for ext in COVERAGE_EXTENSIONS])


### PR DESCRIPTION
I've looked at a report and noticed there are files with these extensions that we were ignoring.