### PR TITLE
shipit_uplift: Set maximum number of workers loading from codecov.io to 4

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -70,7 +70,7 @@ def generate(changeset):
     def parse_diff_task(diff):
         return lambda: parse_diff(diff)
 
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=4) as executor:
         futures = []
 
         for diff in whatthepatch.parse_patch(patch):


### PR DESCRIPTION
I'm seeing codecov.io often returning 500. It might be due to the fact that we are requesting too many files at the same time. Let's try setting a maximum number of threads (that is, basically, the maximum number of connections) to 4.