### PR TITLE
shipit_uplift: Fix worker's exception handling

### DIFF
--- a/src/shipit_uplift/shipit_uplift/worker.py
+++ b/src/shipit_uplift/shipit_uplift/worker.py
@@ -33,5 +33,7 @@ def exc_handler(job, *exc_info):
 
 if __name__ == '__main__':
     with Connection(conn):
-        worker = Worker(map(Queue, ['default']), exception_handlers=[Worker.move_to_failed_queue, exc_handler])
+        worker = Worker(map(Queue, ['default']), exception_handlers=[])
+        worker.push_exc_handler(exc_handler)
+        worker.push_exc_handler(worker.move_to_failed_queue)
         worker.work()


### PR DESCRIPTION
The failing jobs were not actually being put in the `failed` queue. This means some jobs would be `pending` forever.