### PR TITLE
Fixed the Bug 940712. Basically added the favicon to the TryChooser page

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -6,7 +6,7 @@
 <link href="jquery-ui.css" rel="stylesheet" type="text/css">
 <script type="text/javascript" src="jquery.min.js"></script>
 <script type="text/javascript" src="trychooser.js"></script>
-<link rel="shortcut icon" href="favicon.ico">
+<link rel="shortcut icon" href="../favicon.ico">
 <link rel="stylesheet" type="text/css" href="trychooser.css">
 </head>
 <body>


### PR DESCRIPTION
Hi @garbas  

This pull request is in response to the Bug 940712 mentioned [here](https://bugzilla.mozilla.org/show_bug.cgi?id=940712)
I've fixed the favicon issue on the TryChooser page. Please merge this pull request

Thanks,
Aravind Kashyap
