### PR TITLE
shipit_code_coverage, shipit_uplift: Don't preload merge commits and directly return an error for them

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -234,13 +234,16 @@ class CodeCov(object):
 
             # Get pushlog and ask the backend to generate the coverage by changeset
             # data, which will be cached.
-            r = requests.get('https://hg.mozilla.org/mozilla-central/json-pushes?changeset=%s&version=2' % self.revision)
+            r = requests.get('https://hg.mozilla.org/mozilla-central/json-pushes?changeset=%s&version=2&full' % self.revision)
             r.raise_for_status()
             data = r.json()
             changesets = data['pushes'][data['lastpushid']]['changesets']
 
             for changeset in changesets:
-                requests.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/changeset/%s' % changeset)
+                if any(text in changeset['desc'] for text in ['r=merge', 'a=merge']):
+                    continue
+
+                requests.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/changeset/%s' % changeset['node'])
         except Exception as e:
             logger.warn('Error while requesting coverage data: ' + str(e))
 

--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -221,7 +221,8 @@ def get_coverage_build(changeset):
     changeset.
     '''
     r = requests.get('https://hg.mozilla.org/mozilla-central/json-rev/%s' % changeset)
-    push_id = int(r.json()['pushid'])
+    rev = r.json()
+    push_id = int(rev['pushid'])
 
     # In a span of 8 pushes, we hope we will find a successful coverage build.
     pushes = get_push_range(push_id)
@@ -240,7 +241,7 @@ def get_coverage_build(changeset):
 
     assert after_changeset is not None, 'Couldn\'t find a build after the changeset'
 
-    return (after_changeset, after_changeset_overall)
+    return (rev['desc'], after_changeset, after_changeset_overall)
 
 
 def coverage_supported(path):

--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -15,7 +15,9 @@ def generate(changeset):
     This function generates a report containing the coverage information of the diff
     introduced by a changeset.
     '''
-    build_changeset, overall = get_coverage_build(changeset)
+    desc, build_changeset, overall = get_coverage_build(changeset)
+    if any(text in desc for text in ['r=merge', 'a=merge']):
+        raise Exception('Retrieving coverage for merge commits is not supported.')
 
     r = requests.get('https://hg.mozilla.org/mozilla-central/raw-rev/%s' % changeset)
     patch = r.text


### PR DESCRIPTION
Fixes #680.