### PR TITLE
frontend_common: taskcluster login was not reflacting its state

### DIFF
--- a/lib/frontend_common/TaskclusterLogin.elm
+++ b/lib/frontend_common/TaskclusterLogin.elm
@@ -66,17 +66,18 @@ type Msg
 init : String -> Maybe Tokens -> ( Model, Cmd Msg )
 init backend_url tokens =
     let
-        model =
+        model_ =
             { code = Nothing
             , tokens = tokens
             , credentials = Nothing
             , -- TODO : switch to tokens ?
               backend_url = backend_url
             }
+        ( model, cmd ) = loadTaskclusterCredentials model_
     in
         ( model
         , Cmd.batch
-            [ loadTaskclusterCredentials model
+            [ cmd
             , Task.perform CheckTaskclusterCredentials Time.now
             ]
         )
@@ -130,37 +131,60 @@ update msg model =
                         }
             in
                 -- Exchange code for tokens through backend
-                ( model, Http.send ExchangedTokens request )
+                ( { model | code = Just code }
+                , Http.send ExchangedTokens request
+                )
 
         ExchangedTokens response ->
             -- Received tokens from backend
             -- Store in localstorage
             case response of
                 Ok tokens ->
-                    let
-                        x =
-                            Debug.log "tokens" tokens
-                    in
-                        ( { model | tokens = Just tokens }, auth_set tokens )
+                    ( { model | tokens = Just tokens }
+                    , auth_set tokens
+                    )
 
                 Err error ->
                     -- TODO: display error ?
                     ( model, Cmd.none )
 
         Logged tokens ->
-            let
-                model_ =
-                    { model | tokens = tokens }
-            in
-                ( model_, loadTaskclusterCredentials model_ )
+            loadTaskclusterCredentials { model | tokens = tokens }
 
         Logout ->
             ( model, auth_remove True )
 
         CheckTaskclusterCredentials time ->
+            -- TODO: can we renew tokens? we would need to store model.code
+            --       in localStorage
+            --if isTokenExpired time model.tokens then
+            --   case model.code of
+            --       Just code ->
+            --           let
+            --                payload =
+            --                    JsonEncode.object
+            --                        [ ( "code", JsonEncode.string code.code )
+            --                        , ( "state", JsonEncode.string code.state )
+            --                        ]
+            --                request =
+            --                    Http.request
+            --                        { method = "POST"
+            --                        , headers = []
+            --                        , url = (model.backend_url ++ "/auth0/check")
+            --                        , body = Http.jsonBody payload
+            --                        , expect = Http.expectJson decodeTokens
+            --                        , timeout = Nothing
+            --                        , withCredentials = False
+            --                        }
+            --            in
+            --                ( model, Http.send ExchangedTokens request )
+
+            --       Nothing ->
+            --           ( model, Cmd.none )
+
             -- Renew automatically certificate
             if isCertificateExpired time model.credentials then
-                ( model, loadTaskclusterCredentials model )
+                loadTaskclusterCredentials model
             else
                 ( model, Cmd.none )
 
@@ -173,7 +197,7 @@ update msg model =
                     ( { model | credentials = Nothing }, Cmd.none )
 
 
-loadTaskclusterCredentials : Model -> Cmd Msg
+loadTaskclusterCredentials : Model -> ( Model, Cmd Msg )
 loadTaskclusterCredentials model =
     case model.tokens of
         Just tokens ->
@@ -194,10 +218,17 @@ loadTaskclusterCredentials model =
                         , withCredentials = False
                         }
             in
-                Http.send LoadedTaskclusterCredentials request
+                ( model
+                , Http.send LoadedTaskclusterCredentials request
+                )
 
         Nothing ->
-            Cmd.none
+            ( { model | code = Nothing
+                      , tokens = Nothing
+                      , credentials = Nothing
+              }
+            , Cmd.none
+            )
 
 
 decodeTokens : Decoder Tokens
@@ -232,11 +263,23 @@ decodeDate =
         JsonDecode.string
 
 
+isTokenExpired : Float -> Maybe Tokens -> Bool
+isTokenExpired time tokens = 
+    case tokens of
+        Just tokens_ ->
+            if time > ((toFloat tokens_.expires) * 1000)
+               then True
+               else False
+
+        Nothing ->
+            False
+
+
 isCertificateExpired : Float -> Maybe Credentials -> Bool
 isCertificateExpired time credentials =
     case credentials of
         Just credentials_ ->
-            if time > credentials_.expires then
+            if time > (credentials_.expires * 1000) then
                 True
             else
                 False

--- a/lib/frontend_common/TaskclusterLogin.elm
+++ b/lib/frontend_common/TaskclusterLogin.elm
@@ -73,7 +73,9 @@ init backend_url tokens =
             , -- TODO : switch to tokens ?
               backend_url = backend_url
             }
-        ( model, cmd ) = loadTaskclusterCredentials model_
+
+        ( model, cmd ) =
+            loadTaskclusterCredentials model_
     in
         ( model
         , Cmd.batch
@@ -178,10 +180,8 @@ update msg model =
             --                        }
             --            in
             --                ( model, Http.send ExchangedTokens request )
-
             --       Nothing ->
             --           ( model, Cmd.none )
-
             -- Renew automatically certificate
             if isCertificateExpired time model.credentials then
                 loadTaskclusterCredentials model
@@ -223,9 +223,10 @@ loadTaskclusterCredentials model =
                 )
 
         Nothing ->
-            ( { model | code = Nothing
-                      , tokens = Nothing
-                      , credentials = Nothing
+            ( { model
+                | code = Nothing
+                , tokens = Nothing
+                , credentials = Nothing
               }
             , Cmd.none
             )
@@ -264,12 +265,13 @@ decodeDate =
 
 
 isTokenExpired : Float -> Maybe Tokens -> Bool
-isTokenExpired time tokens = 
+isTokenExpired time tokens =
     case tokens of
         Just tokens_ ->
-            if time > ((toFloat tokens_.expires) * 1000)
-               then True
-               else False
+            if time > ((toFloat tokens_.expires) * 1000) then
+                True
+            else
+                False
 
         Nothing ->
             False

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -299,7 +299,7 @@ PROJECTS = {
         ],
         'run': 'FLASK',
         'run_options': {
-            'port': 8003,
+            'port': 8010,
         },
         'requires': [
             'postgresql',

--- a/lib/please_cli/please_cli/run.py
+++ b/lib/please_cli/please_cli/run.py
@@ -50,8 +50,27 @@ PROJECTS:
     default=please_cli.config.NIX_BIN_DIR + 'nix-shell',
     help='`nix-shell` command',
     )
+@click.option(
+    '--taskcluster-secrets',
+    default='repo:github.com/mozilla-releng/services:branch:master',
+    help='Taskcluster secrets',
+    )
+@click.option(
+    '--taskcluster-client-id',
+    default=None,
+    help='Taskcluster client id',
+    )
+@click.option(
+    '--taskcluster-access-token',
+    default=None,
+    help='Taskcluster access token',
+    )
 @click.pass_context
-def cmd(ctx, project, quiet, nix_shell):
+def cmd(ctx, project, quiet, nix_shell,
+        taskcluster_secrets,
+        taskcluster_client_id,
+        taskcluster_access_token,
+        ):
 
     project_config = please_cli.config.PROJECTS.get(project, {})
     run_type = project_config.get('run')
@@ -247,6 +266,9 @@ def cmd(ctx, project, quiet, nix_shell):
                                            quiet=quiet,
                                            command=' '.join(command),
                                            nix_shell=nix_shell,
+                                           taskcluster_secrets=taskcluster_secrets,
+                                           taskcluster_client_id=taskcluster_client_id,
+                                           taskcluster_access_token=taskcluster_access_token,
                                            )
     sys.exit(returncode)
 

--- a/lib/please_cli/please_cli/shell.py
+++ b/lib/please_cli/please_cli/shell.py
@@ -82,7 +82,26 @@ EXAMPLES:
         please_cli.config.NIX_BIN_DIR + 'nix-shell',
         ),
     )
-def cmd(project, zsh, quiet, command, nix_shell):
+@click.option(
+    '--taskcluster-secrets',
+    default='repo:github.com/mozilla-releng/services:branch:master',
+    help='Taskcluster secrets',
+    )
+@click.option(
+    '--taskcluster-client-id',
+    default=None,
+    help='Taskcluster client id',
+    )
+@click.option(
+    '--taskcluster-access-token',
+    default=None,
+    help='Taskcluster access token',
+    )
+def cmd(project, zsh, quiet, command, nix_shell,
+        taskcluster_secrets,
+        taskcluster_client_id,
+        taskcluster_access_token,
+        ):
 
     run = []
     if zsh or command:
@@ -101,6 +120,12 @@ def cmd(project, zsh, quiet, command, nix_shell):
 
     os.environ['SERVICES_ROOT'] = please_cli.config.ROOT_DIR + '/'
     os.environ['SSL_DEV_CA'] = os.path.join(please_cli.config.TMP_DIR, 'certs')
+    os.environ['PYTHONPATH'] = ""
+    os.environ['TASKCLUSTER_SECRET'] = taskcluster_secrets
+    if taskcluster_client_id:
+        os.environ['TASKCLUSTER_CLIENT_ID'] = taskcluster_client_id
+    if taskcluster_access_token:
+        os.environ['TASKCLUSTER_ACCESS_TOKEN'] = taskcluster_access_token
 
     if command:
         handle_stream_line = None
@@ -114,7 +139,7 @@ def cmd(project, zsh, quiet, command, nix_shell):
         )
     else:
         log.debug('Running command using os.system', command=_command)
-        return os.system('PYTHONPATH="" ' + ' '.join(_command)) / 256, '', ''
+        return os.system(' '.join(_command)) / 256, '', ''
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- logout message never cleared the model
- taskcluster certificate comes in seconds not miliseconds
- tries to address problems in Bug 1407694[1]
- adds --taskcluster-client-id/--taskcluster-access-token options to
  please run and shell subcommand. that would load configuration from
  taskcluster secrets service.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1407694