### PR TITLE
shipit_code_coverage: Retry operations 5 times instead of 3, with a 120 second delay, and retry "mach build" too when it fails

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -231,8 +231,8 @@ class CodeCov(object):
             f.write('ac_add_options --enable-debug\n')
             f.write('ac_add_options --enable-artifact-builds\n')
 
-        run_check(['gecko-env', './mach', 'build'], cwd=self.repo_dir)
-        run_check(['gecko-env', './mach', 'build-backend', '-b', 'ChromeMap'], cwd=self.repo_dir)
+        retry(lambda: run_check(['gecko-env', './mach', 'build'], cwd=self.repo_dir))
+        retry(lambda: run_check(['gecko-env', './mach', 'build-backend', '-b', 'ChromeMap'], cwd=self.repo_dir))
 
         logger.info('Build successful')
 

--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -16,7 +16,7 @@ def wait_until(operation, timeout=30, interval=60):
     return None
 
 
-def retry(operation, retries=3):
+def retry(operation, retries=5, wait_between_retries=120):
     successful = False
     while not successful and retries > 0:
         try:
@@ -24,6 +24,7 @@ def retry(operation, retries=3):
             successful = True
         except:
             retries -= 1
+            time.sleep(wait_between_retries)
     return successful
 
 

--- a/src/shipit_code_coverage/tests/test_utils.py
+++ b/src/shipit_code_coverage/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_retry():
             i['tried'] = True
             raise Exception('Please try again.')
 
-    assert utils.retry(try_twice)
+    assert utils.retry(try_twice, wait_between_retries=0)
 
 
 def test_threadpoolexecutorresult():


### PR DESCRIPTION
Fixes #713.