### PR TITLE
shipit_uplift: Return 'original' line number (that is, the line number when the line was introduced) and fix off-by-one error (enumerate starts from 0, line numbers start from 1)

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -50,11 +50,13 @@ def generate(changeset):
         annotate = r.json()['annotate']
 
         changes = []
-        for new_line, data in enumerate(annotate):
+        for data in annotate:
             # Skip lines that were not added by this changeset or were overwritten by
             # another changeset.
             if data['node'] != changeset:
                 continue
+
+            new_line = data['lineno']
 
             if new_line not in coverage or coverage[new_line] is None:
                 # We have no coverage information for this line (e.g. a definition, like
@@ -67,7 +69,7 @@ def generate(changeset):
 
             changes.append({
                 'coverage': covered,
-                'line': new_line,
+                'line': data['targetline'],
             })
 
         return {


### PR DESCRIPTION
Fixes #718.
Fixes #719.