### PR TITLE
shipit_code_coverage: Consider Windows coverage tasks as coverage tasks

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -83,11 +83,17 @@ def download_artifact(task_id, suite, artifact):
     return artifact_path
 
 
+TEST_PLATFORMS = ['test-linux64-ccov/opt', 'test-windows10-64-ccov/debug']
+
+
 def is_coverage_task(task):
-    return task['task']['metadata']['name'].startswith('test-linux64-ccov')
+    return any(task['task']['metadata']['name'].startswith(t) for t in TEST_PLATFORMS)
 
 
 def get_suite_name(task):
     name = task['task']['metadata']['name']
-    name = name[len('test-linux64-ccov/opt-'):]
+    for t in TEST_PLATFORMS:
+        if name.startswith(t):
+            name = name[len(t) + 1:]
+            break
     return '-'.join([p for p in name.split('-') if p != 'e10s' and not p.isdigit()])

--- a/src/shipit_code_coverage/tests/test_taskcluster.py
+++ b/src/shipit_code_coverage/tests/test_taskcluster.py
@@ -59,12 +59,34 @@ def test_is_coverage_task():
     }
     assert not taskcluster.is_coverage_task(nocov_task)
 
+    cov_task = {
+        'task': {
+            'metadata': {
+                'name': 'test-windows10-64-ccov/debug-cppunit'
+            }
+        }
+    }
+    assert taskcluster.is_coverage_task(cov_task)
+
+    nocov_task = {
+        'task': {
+            'metadata': {
+                'name': 'test-windows10-64/debug-cppunit'
+            }
+        }
+    }
+    assert not taskcluster.is_coverage_task(nocov_task)
+
 
 def test_get_suite_name():
     tests = [
         ('test-linux64-ccov/opt-mochitest-1', 'mochitest'),
         ('test-linux64-ccov/opt-mochitest-e10s-7', 'mochitest'),
-        ('test-linux64-ccov/opt-firefox-ui-functional-remote-e10s', 'firefox-ui-functional-remote')
+        ('test-linux64-ccov/opt-cppunit', 'cppunit'),
+        ('test-linux64-ccov/opt-firefox-ui-functional-remote-e10s', 'firefox-ui-functional-remote'),
+        ('test-windows10-64-ccov/debug-mochitest-1', 'mochitest'),
+        ('test-windows10-64-ccov/debug-mochitest-e10s-7', 'mochitest'),
+        ('test-windows10-64-ccov/debug-cppunit', 'cppunit'),
     ]
 
     for (name, suite) in tests:


### PR DESCRIPTION
`test-linux64-ccov` was hardcoded in `is_coverage_task`, so Windows coverage tasks were not being considered as coverage tasks.