### PR TITLE
shipit_uplift: Support using short revisions when retrieving coverage info for a changeset and always use short revisions

### DIFF
--- a/src/shipit_uplift/shipit_uplift/api.py
+++ b/src/shipit_uplift/shipit_uplift/api.py
@@ -387,6 +387,8 @@ def coverage_by_dir(path=''):
 
 
 def coverage_by_changeset(changeset):
+    changeset = changeset[:12]
+
     job = q.fetch_job(changeset)
 
     if job is None:

--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -53,7 +53,7 @@ def generate(changeset):
         for data in annotate:
             # Skip lines that were not added by this changeset or were overwritten by
             # another changeset.
-            if data['node'] != changeset:
+            if data['node'][:len(changeset)] != changeset:
                 continue
 
             new_line = data['lineno']


### PR DESCRIPTION
By always using short revisions, we avoid duplicating cached results in case they are requested once in the long format and once in the short format.