### PR TITLE
shipit_code_coverage: Don't actually wait when testing the 'retry' function from utils

### DIFF
--- a/src/shipit_code_coverage/tests/test_utils.py
+++ b/src/shipit_code_coverage/tests/test_utils.py
@@ -30,7 +30,7 @@ def test_wait_until():
 def test_retry():
     assert utils.retry(lambda: True)
     assert utils.retry(lambda: False)
-    assert not utils.retry(do_raise)
+    assert not utils.retry(do_raise, wait_between_retries=0)
 
     i = {}
 


### PR DESCRIPTION
This saves 10 minutes during tests 😄 