### PR TITLE
shipit_code_coverage: Temporarily copy chrome-map.json file from the obj directory to the src directory to avoid fallout when bug 1431349 lands

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -306,6 +306,9 @@ class CodeCov(object):
 
         retry(lambda: run_check(['gecko-env', './mach', 'build'], cwd=self.repo_dir))
         retry(lambda: run_check(['gecko-env', './mach', 'build-backend', '-b', 'ChromeMap'], cwd=self.repo_dir))
+        # XXX: Temporarily copy the chrome-map.json to the working directory of the lcov rewriter
+        # to avoid issues when bug 1431349 lands.
+        shutil.copyfile(os.path.join(self.repo_dir, 'obj-firefox/chrome-map.json'), os.path.join(self.repo_dir, 'chrome-map.json'))
 
         logger.info('Build successful')
 


### PR DESCRIPTION
In the short time between bug 1431349 landing and updating the task to cope with its changes, we will need to copy the chrome-map.json in the src directory.