### PR TITLE
shipit_code_coverage: Stop building Firefox and use platform-specific chrome-map.json files to rewrite LCOV

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -224,14 +224,18 @@ class CodeCov(object):
 
         with ZipFile(zip_file_path, 'r') as z:
             z.extractall(out_dir)
-
-        run_check([
-            'gecko-env', './mach', 'python',
-            'python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py',
-            os.path.abspath(out_dir),
-            '--output-file', os.path.abspath(out_file),
-            '--chrome-map-path', os.path.abspath('%s_chrome-map.json' % platform_name),
-        ], cwd=self.repo_dir)
+            files = z.namelist()
+            if len(files) == 1 and files[0] == 'jsvm_lcov_output.info':
+                # The file was rewritten on the test machine.
+                os.rename(os.path.join(out_dir, 'jsvm_lcov_output.info'), out_file)
+            else:
+                run_check([
+                    'gecko-env', './mach', 'python',
+                    'python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py',
+                    os.path.abspath(out_dir),
+                    '--output-file', os.path.abspath(out_file),
+                    '--chrome-map-path', os.path.abspath('%s_chrome-map.json' % platform_name),
+                ], cwd=self.repo_dir)
 
         shutil.rmtree(out_dir)
 

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -44,12 +44,12 @@ class CodeCov(object):
         self.access_token = access_token
 
         if revision is None:
-            self.task_ids = [
-                taskcluster.get_last_task('linux'),
-                taskcluster.get_last_task('win'),
-            ]
+            self.task_ids = {
+                'linux': taskcluster.get_last_task('linux'),
+                'windows': taskcluster.get_last_task('win'),
+            }
 
-            task_data = taskcluster.get_task_details(self.task_ids[0])
+            task_data = taskcluster.get_task_details(self.task_ids['linux'])
             self.revision = task_data['payload']['env']['GECKO_HEAD_REV']
             self.coveralls_token = 'NONE'
             self.codecov_token = 'NONE'
@@ -57,22 +57,25 @@ class CodeCov(object):
             logger.info('Mercurial revision', revision=self.revision)
         else:
             logger.info('Mercurial revision', revision=revision)
-            self.task_ids = [
-                taskcluster.get_task('mozilla-central', revision, 'linux'),
-                taskcluster.get_task('mozilla-central', revision, 'win'),
-            ]
+            self.task_ids = {
+                'linux': taskcluster.get_task('mozilla-central', revision, 'linux'),
+                'windows': taskcluster.get_task('mozilla-central', revision, 'win'),
+            }
             self.revision = revision
             self.coveralls_token = coveralls_token
             self.codecov_token = codecov_token
             self.from_pulse = True
 
-        self.build_finished = False
-        self.build_finished_cv = Condition()
+        self.configure_finished = False
+        self.configure_finished_cv = Condition()
 
         if self.from_pulse:
             self.suites_to_ignore = ['awsy', 'talos']
         else:
             self.suites_to_ignore = []
+
+    def get_artifact_path(self, platform, chunk, artifact):
+        return 'ccov-artifacts/%s_%s_%s' % (platform, chunk, os.path.basename(artifact['name']))
 
     def get_chunks(self):
         return list(set([f.split('_')[1] for f in os.listdir('ccov-artifacts')]))
@@ -109,13 +112,16 @@ class CodeCov(object):
         # The test tasks for the Linux and Windows builds are in the same group,
         # but the following code is generic and supports build tasks split in
         # separate groups.
-        groups = set([taskcluster.get_task_details(build_task_id)['taskGroupId'] for build_task_id in self.task_ids])
+        groups = set([taskcluster.get_task_details(build_task_id)['taskGroupId'] for build_task_id in self.task_ids.values()])
         test_tasks = [
             task
             for group in groups
             for task in taskcluster.get_tasks_in_group(group)
             if taskcluster.is_coverage_task(task)
         ]
+
+        for platform, build_task_id in self.task_ids.items():
+            taskcluster.download_artifact('%s_chrome-map.json' % platform, build_task_id, 'public/build/chrome-map.json')
 
         FINISHED_STATUSES = ['completed', 'failed', 'exception']
         ALL_STATUSES = FINISHED_STATUSES + ['unscheduled', 'pending', 'running']
@@ -160,10 +166,11 @@ class CodeCov(object):
                 if not any(n in artifact['name'] for n in ['code-coverage-grcov.zip', 'code-coverage-jsvm.zip']):
                     continue
 
-                artifact_path = taskcluster.download_artifact(test_task_id, chunk_name, platform_name, artifact)
+                artifact_path = self.get_artifact_path(platform_name, chunk_name, artifact)
+                taskcluster.download_artifact(artifact_path, test_task_id, artifact['name'])
                 logger.info('%s artifact downloaded' % artifact_path)
                 if 'code-coverage-jsvm.zip' in artifact['name']:
-                    self.rewrite_jsvm_lcov(artifact_path)
+                    self.rewrite_jsvm_lcov(platform_name, artifact_path)
                     logger.info('%s artifact rewritten' % artifact_path)
 
         def download_artifact_task(test_task):
@@ -207,10 +214,10 @@ class CodeCov(object):
             raise Exception('Mercurial commit is not available yet on mozilla/gecko-dev.')
         return ret
 
-    def rewrite_jsvm_lcov(self, zip_file_path):
-        with self.build_finished_cv:
-            while not self.build_finished:
-                self.build_finished_cv.wait()
+    def rewrite_jsvm_lcov(self, platform_name, zip_file_path):
+        with self.configure_finished_cv:
+            while not self.configure_finished:
+                self.configure_finished_cv.wait()
 
         out_dir = zip_file_path[:-4]
         out_file = out_dir + '.info'
@@ -222,7 +229,8 @@ class CodeCov(object):
             'gecko-env', './mach', 'python',
             'python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py',
             os.path.abspath(out_dir),
-            '--output-file', os.path.abspath(out_file)
+            '--output-file', os.path.abspath(out_file),
+            '--chrome-map-path', os.path.abspath('%s_chrome-map.json' % platform_name),
         ], cwd=self.repo_dir)
 
         shutil.rmtree(out_dir)
@@ -298,23 +306,15 @@ class CodeCov(object):
 
         logger.info('mozilla-central cloned')
 
-    def build_files(self):
-        with open(os.path.join(self.repo_dir, '.mozconfig'), 'w') as f:
-            f.write('mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-firefox\n')
-            f.write('ac_add_options --enable-debug\n')
-            f.write('ac_add_options --enable-artifact-builds\n')
+    def configure_repo(self):
+        # Run ./mach python --version to create the virtualenv.
+        run_check(['gecko-env', './mach', 'python', '--version'], cwd=self.repo_dir)
 
-        retry(lambda: run_check(['gecko-env', './mach', 'build'], cwd=self.repo_dir))
-        retry(lambda: run_check(['gecko-env', './mach', 'build-backend', '-b', 'ChromeMap'], cwd=self.repo_dir))
-        # XXX: Temporarily copy the chrome-map.json to the working directory of the lcov rewriter
-        # to avoid issues when bug 1431349 lands.
-        shutil.copyfile(os.path.join(self.repo_dir, 'obj-firefox/chrome-map.json'), os.path.join(self.repo_dir, 'chrome-map.json'))
+        logger.info('Configured successfully')
 
-        logger.info('Build successful')
-
-        self.build_finished = True
-        with self.build_finished_cv:
-            self.build_finished_cv.notify_all()
+        self.configure_finished = True
+        with self.configure_finished_cv:
+            self.configure_finished_cv.notify_all()
 
     def prepopulate_cache(self, commit_sha):
         try:
@@ -440,12 +440,12 @@ class CodeCov(object):
             # Thread 1 - Download coverage artifacts.
             executor.submit(lambda: self.download_coverage_artifacts())
 
-            # Thread 2 - Clone and build mozilla-central
+            # Thread 2 - Clone and configure mozilla-central
             clone_future = executor.submit(lambda: self.clone_mozilla_central(self.revision))
-            # Make sure cloning mozilla-central didn't fail before building.
+            # Make sure cloning mozilla-central didn't fail before configuring.
             clone_future.add_done_callback(lambda f: f.result())
-            # Now we can build.
-            clone_future.add_done_callback(lambda f: self.build_files())
+            # Now we can configure.
+            clone_future.add_done_callback(lambda f: self.configure_repo())
 
         if self.from_pulse:
             if self.gecko_dev_user is not None and self.gecko_dev_pwd is not None:

--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -69,14 +69,12 @@ def get_tasks_in_group(group_id):
     return tasks
 
 
-def download_artifact(task_id, chunk, platform, artifact):
-    artifact_path = 'ccov-artifacts/%s_%s_%s' % (platform, chunk, os.path.basename(artifact['name']))
-
+def download_artifact(artifact_path, task_id, artifact_name):
     if os.path.exists(artifact_path):
         return artifact_path
 
     def perform_download():
-        r = requests.get(queue_base + 'task/%s/artifacts/%s' % (task_id, artifact['name']), stream=True)
+        r = requests.get(queue_base + 'task/%s/artifacts/%s' % (task_id, artifact_name), stream=True)
 
         with open(artifact_path, 'wb') as f:
             r.raw.decode_content = True
@@ -84,8 +82,6 @@ def download_artifact(task_id, chunk, platform, artifact):
 
     if not retry(perform_download):
         raise Exception('Failed downloading artifact in %s' % artifact_path)
-
-    return artifact_path
 
 
 TEST_PLATFORMS = ['test-linux64-ccov/opt', 'test-windows10-64-ccov/debug']


### PR DESCRIPTION
This fixes #486 and fixes #781.