### PR TITLE
shipit_code_coverage: Log mercurial revision as soon as possible

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -54,7 +54,9 @@ class CodeCov(object):
             self.coveralls_token = 'NONE'
             self.codecov_token = 'NONE'
             self.from_pulse = False
+            logger.info('Mercurial revision', revision=self.revision)
         else:
+            logger.info('Mercurial revision', revision=revision)
             self.task_ids = [
                 taskcluster.get_task('mozilla-central', revision, 'linux'),
                 taskcluster.get_task('mozilla-central', revision, 'win'),
@@ -71,8 +73,6 @@ class CodeCov(object):
             self.suites_to_ignore = ['awsy', 'talos']
         else:
             self.suites_to_ignore = []
-
-        logger.info('Mercurial revision', revision=self.revision)
 
     def get_chunks(self):
         return list(set([f.split('_')[1] for f in os.listdir('ccov-artifacts')]))


### PR DESCRIPTION
When the coverage build fails, `taskcluster.get_task` raises an exception and so we are not able to see the revision.
It would be useful to see the revision so that we can confirm the coverage build failed and we can check why it failed.