### PR TITLE
shipit_code_coverage: Refactor artifacts- and github-related code in separate modules

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import os
+from threading import Lock
+import time
+
+from cli_common.log import get_logger
+
+from shipit_code_coverage import taskcluster
+from shipit_code_coverage.utils import mkdir, ThreadPoolExecutorResult
+
+
+logger = get_logger(__name__)
+
+
+FINISHED_STATUSES = ['completed', 'failed', 'exception']
+ALL_STATUSES = FINISHED_STATUSES + ['unscheduled', 'pending', 'running']
+STATUS_VALUE = {
+    'exception': 1,
+    'failed': 2,
+    'completed': 3,
+}
+
+
+class ArtifactsHandler(object):
+
+    def __init__(self, task_ids, suites_to_ignore):
+        self.task_ids = task_ids
+        self.suites_to_ignore = suites_to_ignore
+        self.download_tasks = {}
+        self.download_tasks_lock = Lock()
+
+    def get_artifact_path(self, platform, chunk, artifact):
+        return 'ccov-artifacts/%s_%s_%s' % (platform, chunk, os.path.basename(artifact['name']))
+
+    def get_chunks(self):
+        return list(set([f.split('_')[1] for f in os.listdir('ccov-artifacts')]))
+
+    def get_coverage_artifacts(self, suite=None, chunk=None):
+        files = os.listdir('ccov-artifacts')
+
+        if suite is not None and chunk is not None:
+            raise Exception('suite and chunk can\'t both have a value')
+
+        filtered_files = []
+        for fname in files:
+            # grcov artifacts always have 'grcov' in the name and are ZIP files.
+            if 'grcov' in fname and not fname.endswith('.zip'):
+                continue
+            # jsvm artifacts always have 'jsvm' in the name and are not ZIP files.
+            if 'jsvm' in fname and fname.endswith('.zip'):
+                continue
+
+            # If suite and chunk are None, return all artifacts.
+            # Otherwise, only return the ones which have suite or chunk in their name.
+            if (
+                   (suite is None and chunk is None) or
+                   (suite is not None and ('%s' % suite) in fname) or
+                   (chunk is not None and ('%s_code-coverage' % chunk) in fname)
+               ):
+                filtered_files.append('ccov-artifacts/' + fname)
+
+        return filtered_files
+
+    def should_download(self, status, chunk_name, platform_name):
+        with self.download_tasks_lock:
+            # If the chunk hasn't been downloaded before, this is obviously the best task
+            # to download it from.
+            if (chunk_name, platform_name) not in self.download_tasks:
+                download_lock = Lock()
+                self.download_tasks[(chunk_name, platform_name)] = {
+                    'status': status,
+                    'lock': download_lock,
+                }
+            else:
+                task = self.download_tasks[(chunk_name, platform_name)]
+
+                if STATUS_VALUE[status] > STATUS_VALUE[task['status']]:
+                    task['status'] = status
+                    download_lock = task['lock']
+                else:
+                    return None
+
+            download_lock.acquire()
+            return download_lock
+
+    def download_coverage_artifact(self, test_task):
+        status = test_task['status']['state']
+        assert status in ALL_STATUSES
+        while status not in FINISHED_STATUSES:
+            time.sleep(60)
+            status = taskcluster.get_task_status(test_task['status']['taskId'])['status']['state']
+            assert status in ALL_STATUSES
+
+        chunk_name = taskcluster.get_chunk_name(test_task)
+        platform_name = taskcluster.get_platform_name(test_task)
+        # Ignore any chunk belonging to suites we should ignore.
+        if any(to_ignore in chunk_name for to_ignore in self.suites_to_ignore):
+            return
+
+        # If we have already downloaded this chunk from another task, check if the
+        # other task has a better status than this one.
+        download_lock = self.should_download(status, chunk_name, platform_name)
+        if download_lock is None:
+            return
+
+        test_task_id = test_task['status']['taskId']
+        for artifact in taskcluster.get_task_artifacts(test_task_id):
+            if not any(n in artifact['name'] for n in ['code-coverage-grcov.zip', 'code-coverage-jsvm.zip']):
+                continue
+
+            artifact_path = self.get_artifact_path(platform_name, chunk_name, artifact)
+            taskcluster.download_artifact(artifact_path, test_task_id, artifact['name'])
+            logger.info('%s artifact downloaded' % artifact_path)
+
+        download_lock.release()
+
+    def download_coverage_artifacts(self):
+        mkdir('ccov-artifacts')
+
+        # The test tasks for the Linux and Windows builds are in the same group,
+        # but the following code is generic and supports build tasks split in
+        # separate groups.
+        groups = set([taskcluster.get_task_details(build_task_id)['taskGroupId'] for build_task_id in self.task_ids.values()])
+        test_tasks = [
+            task
+            for group in groups
+            for task in taskcluster.get_tasks_in_group(group)
+            if taskcluster.is_coverage_task(task)
+        ]
+
+        for platform, build_task_id in self.task_ids.items():
+            taskcluster.download_artifact('%s_chrome-map.json' % platform, build_task_id, 'public/build/chrome-map.json')
+
+        def download_artifact_task(test_task):
+            return lambda: self.download_coverage_artifact(test_task)
+
+        with ThreadPoolExecutorResult() as executor:
+            for test_task in test_tasks:
+                executor.submit(download_artifact_task(test_task))
+
+        logger.info('Code coverage artifacts downloaded')

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -5,18 +5,17 @@ import shutil
 import tarfile
 import requests
 import hglib
-from threading import Lock
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 import sqlite3
-import time
 
 from cli_common.log import get_logger
 from cli_common.command import run_check
-from cli_common.taskcluster import get_service
 
 from shipit_code_coverage import taskcluster, uploader
-from shipit_code_coverage.utils import mkdir, wait_until, retry, ThreadPoolExecutorResult
+from shipit_code_coverage.artifacts import ArtifactsHandler
+from shipit_code_coverage.github import GitHubUtils
+from shipit_code_coverage.utils import mkdir, retry, ThreadPoolExecutorResult
 
 
 logger = get_logger(__name__)
@@ -37,182 +36,34 @@ class CodeCov(object):
         assert os.path.isdir(cache_root), 'Cache root {} is not a dir.'.format(cache_root)
         self.repo_dir = os.path.join(cache_root, 'mozilla-central')
 
-        self.gecko_dev_user = gecko_dev_user
-        self.gecko_dev_pwd = gecko_dev_pwd
-        self.client_id = client_id
-        self.access_token = access_token
-
         if revision is None:
-            self.task_ids = {
+            task_ids = {
                 'linux': taskcluster.get_last_task('linux'),
                 'windows': taskcluster.get_last_task('win'),
             }
 
-            task_data = taskcluster.get_task_details(self.task_ids['linux'])
+            task_data = taskcluster.get_task_details(task_ids['linux'])
             self.revision = task_data['payload']['env']['GECKO_HEAD_REV']
             self.coveralls_token = 'NONE'
             self.codecov_token = 'NONE'
+            # Ignore awsy and talos as they aren't actually suites of tests.
+            suites_to_ignore = ['awsy', 'talos']
             self.from_pulse = False
-            logger.info('Mercurial revision', revision=self.revision)
         else:
-            logger.info('Mercurial revision', revision=revision)
-            self.task_ids = {
+            task_ids = {
                 'linux': taskcluster.get_task('mozilla-central', revision, 'linux'),
                 'windows': taskcluster.get_task('mozilla-central', revision, 'win'),
             }
             self.revision = revision
             self.coveralls_token = coveralls_token
             self.codecov_token = codecov_token
+            suites_to_ignore = []
             self.from_pulse = True
 
-        if self.from_pulse:
-            self.suites_to_ignore = ['awsy', 'talos']
-        else:
-            self.suites_to_ignore = []
+        logger.info('Mercurial revision', revision=self.revision)
 
-    def get_artifact_path(self, platform, chunk, artifact):
-        return 'ccov-artifacts/%s_%s_%s' % (platform, chunk, os.path.basename(artifact['name']))
-
-    def get_chunks(self):
-        return list(set([f.split('_')[1] for f in os.listdir('ccov-artifacts')]))
-
-    def get_coverage_artifacts(self, suite=None, chunk=None):
-        files = os.listdir('ccov-artifacts')
-
-        if suite is not None and chunk is not None:
-            raise Exception('suite and chunk can\'t both have a value')
-
-        filtered_files = []
-        for fname in files:
-            # If suite and chunk are None, return all artifacts.
-            # Otherwise, only return the ones which have suite or chunk in their name.
-            if (
-                   (suite is None and chunk is None) or
-                   (suite is not None and ('%s' % suite) in fname) or
-                   (chunk is not None and ('%s_code-coverage' % chunk) in fname)
-               ):
-                filtered_files.append('ccov-artifacts/' + fname)
-
-        return filtered_files
-
-    def download_coverage_artifacts(self):
-        mkdir('ccov-artifacts')
-
-        # The test tasks for the Linux and Windows builds are in the same group,
-        # but the following code is generic and supports build tasks split in
-        # separate groups.
-        groups = set([taskcluster.get_task_details(build_task_id)['taskGroupId'] for build_task_id in self.task_ids.values()])
-        test_tasks = [
-            task
-            for group in groups
-            for task in taskcluster.get_tasks_in_group(group)
-            if taskcluster.is_coverage_task(task)
-        ]
-
-        FINISHED_STATUSES = ['completed', 'failed', 'exception']
-        ALL_STATUSES = FINISHED_STATUSES + ['unscheduled', 'pending', 'running']
-        STATUS_VALUE = {
-            'exception': 1,
-            'failed': 2,
-            'completed': 3,
-        }
-
-        downloaded_tasks = {}
-        downloaded_tasks_lock = Lock()
-
-        def should_download(status, chunk_name, platform_name):
-            with downloaded_tasks_lock:
-                # If the chunk hasn't been downloaded before, this is obviously the best task
-                # to download it from.
-                if (chunk_name, platform_name) not in downloaded_tasks:
-                    download_lock = Lock()
-                    downloaded_tasks[(chunk_name, platform_name)] = {
-                        'status': status,
-                        'lock': download_lock,
-                    }
-                else:
-                    task = downloaded_tasks[(chunk_name, platform_name)]
-
-                    if STATUS_VALUE[status] > STATUS_VALUE[task['status']]:
-                        task['status'] = status
-                        download_lock = task['lock']
-                    else:
-                        return None
-
-                download_lock.acquire()
-                return download_lock
-
-        def download_artifact(test_task):
-            status = test_task['status']['state']
-            assert status in ALL_STATUSES
-            while status not in FINISHED_STATUSES:
-                time.sleep(60)
-                status = taskcluster.get_task_status(test_task['status']['taskId'])['status']['state']
-                assert status in ALL_STATUSES
-
-            chunk_name = taskcluster.get_chunk_name(test_task)
-            platform_name = taskcluster.get_platform_name(test_task)
-            # Ignore awsy and talos as they aren't actually suites of tests.
-            if any(to_ignore in chunk_name for to_ignore in self.suites_to_ignore):
-                return
-
-            # If we have already downloaded this chunk from another task, check if the
-            # other task has a better status than this one.
-            download_lock = should_download(status, chunk_name, platform_name)
-            if download_lock is None:
-                return
-
-            test_task_id = test_task['status']['taskId']
-            for artifact in taskcluster.get_task_artifacts(test_task_id):
-                if not any(n in artifact['name'] for n in ['code-coverage-grcov.zip', 'code-coverage-jsvm.zip']):
-                    continue
-
-                artifact_path = self.get_artifact_path(platform_name, chunk_name, artifact)
-                taskcluster.download_artifact(artifact_path, test_task_id, artifact['name'])
-                logger.info('%s artifact downloaded' % artifact_path)
-
-            download_lock.release()
-
-        def download_artifact_task(test_task):
-            return lambda: download_artifact(test_task)
-
-        with ThreadPoolExecutorResult() as executor:
-            for test_task in test_tasks:
-                executor.submit(download_artifact_task(test_task))
-
-        logger.info('Code coverage artifacts downloaded')
-
-    def update_github_repo(self):
-        run_check(['git', 'config', '--global', 'http.postBuffer', '12M'])
-        repo_url = 'https://%s:%s@github.com/marco-c/gecko-dev' % (self.gecko_dev_user, self.gecko_dev_pwd)
-        repo_path = os.path.join(self.cache_root, 'gecko-dev')
-
-        if not os.path.isdir(repo_path):
-            retry(lambda: run_check(['git', 'clone', repo_url], cwd=self.cache_root))
-        retry(lambda: run_check(['git', 'pull', 'https://github.com/mozilla/gecko-dev', 'master'], cwd=repo_path))
-        retry(lambda: run_check(['git', 'push', repo_url, 'master'], cwd=repo_path))
-
-    def post_github_status(self, commit_sha):
-        tcGithub = get_service('github', self.client_id, self.access_token)
-        tcGithub.createStatus('marco-c', 'gecko-dev', commit_sha, {
-            'state': 'success',
-        })
-
-    def get_github_commit(self, mercurial_commit):
-        url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s'
-
-        def get_commit():
-            r = requests.get(url % mercurial_commit)
-
-            if r.status_code == requests.codes.ok:
-                return r.text.split(' ')[0]
-
-            return None
-
-        ret = wait_until(get_commit)
-        if ret is None:
-            raise Exception('Mercurial commit is not available yet on mozilla/gecko-dev.')
-        return ret
+        self.artifactsHandler = ArtifactsHandler(task_ids, suites_to_ignore)
+        self.githubUtils = GitHubUtils(cache_root, gecko_dev_user, gecko_dev_pwd, client_id, access_token)
 
     def generate_info(self, commit_sha=None, suite=None, chunk=None, out_format='coveralls', options=[]):
         cmd = [
@@ -241,7 +92,7 @@ class CodeCov(object):
             else:
                 cmd.extend(['--service-job-number', '1'])
 
-        cmd.extend(self.get_coverage_artifacts(suite, chunk))
+        cmd.extend(self.artifactsHandler.get_coverage_artifacts(suite, chunk))
         cmd.extend(options)
 
         return run_check(cmd)
@@ -389,7 +240,7 @@ class CodeCov(object):
 
         with ThreadPoolExecutor(max_workers=4) as executor:
             futures = []
-            for chunk in self.get_chunks():
+            for chunk in self.artifactsHandler.get_chunks():
                 futures.append(executor.submit(get_files_task(chunk)))
 
             with sqlite3.connect('chunk_mapping.db') as conn:
@@ -407,20 +258,18 @@ class CodeCov(object):
     def go(self):
         with ThreadPoolExecutorResult(max_workers=2) as executor:
             # Thread 1 - Download coverage artifacts.
-            executor.submit(lambda: self.download_coverage_artifacts())
+            executor.submit(lambda: self.artifactsHandler.download_coverage_artifacts())
 
             # Thread 2 - Clone mozilla-central.
             executor.submit(lambda: self.clone_mozilla_central(self.revision))
 
         if self.from_pulse:
-            if self.gecko_dev_user is not None and self.gecko_dev_pwd is not None:
-                self.update_github_repo()
+            self.githubUtils.update_geckodev_repo()
 
-            commit_sha = self.get_github_commit(self.revision)
+            commit_sha = self.githubUtils.get_commit(self.revision)
             logger.info('GitHub revision', revision=commit_sha)
 
-            if self.gecko_dev_user is not None and self.gecko_dev_pwd is not None:
-                self.post_github_status(commit_sha)
+            self.githubUtils.post_status(commit_sha)
 
             output = self.generate_info(commit_sha)
             logger.info('Report generated successfully')
@@ -440,11 +289,4 @@ class CodeCov(object):
             self.generate_chunk_mapping()
 
             os.chdir('code-coverage-reports')
-            run_check(['git', 'config', '--global', 'http.postBuffer', '12M'])
-            run_check(['git', 'config', '--global', 'user.email', 'report@upload.it'])
-            run_check(['git', 'config', '--global', 'user.name', 'Report Uploader'])
-            repo_url = 'https://%s:%s@github.com/marco-c/code-coverage-reports' % (self.gecko_dev_user, self.gecko_dev_pwd)
-            run_check(['git', 'init'])
-            run_check(['git', 'add', '*'])
-            run_check(['git', 'commit', '-m', 'Coverage reports upload'])
-            retry(lambda: run_check(['git', 'push', repo_url, 'master', '--force']))
+            self.githubUtils.update_codecoveragereports_repo()

--- a/src/shipit_code_coverage/shipit_code_coverage/github.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/github.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import os
+import requests
+
+from cli_common.log import get_logger
+from cli_common.command import run_check
+from cli_common.taskcluster import get_service
+
+from shipit_code_coverage.utils import wait_until, retry
+
+
+logger = get_logger(__name__)
+
+
+class GitHubUtils(object):
+
+    def __init__(self, cache_root, gecko_dev_user, gecko_dev_pwd, client_id, access_token):
+        self.cache_root = cache_root
+        self.gecko_dev_user = gecko_dev_user
+        self.gecko_dev_pwd = gecko_dev_pwd
+        self.client_id = client_id
+        self.access_token = access_token
+
+    def update_geckodev_repo(self):
+        if self.gecko_dev_user is None or self.gecko_dev_pwd is None:
+            return
+
+        run_check(['git', 'config', '--global', 'http.postBuffer', '12M'])
+        repo_url = 'https://%s:%s@github.com/marco-c/gecko-dev' % (self.gecko_dev_user, self.gecko_dev_pwd)
+        repo_path = os.path.join(self.cache_root, 'gecko-dev')
+
+        if not os.path.isdir(repo_path):
+            retry(lambda: run_check(['git', 'clone', repo_url], cwd=self.cache_root))
+        retry(lambda: run_check(['git', 'pull', 'https://github.com/mozilla/gecko-dev', 'master'], cwd=repo_path))
+        retry(lambda: run_check(['git', 'push', repo_url, 'master'], cwd=repo_path))
+
+    def post_status(self, commit_sha):
+        if self.gecko_dev_user is None or self.gecko_dev_pwd is None:
+            return
+
+        tcGithub = get_service('github', self.client_id, self.access_token)
+        tcGithub.createStatus('marco-c', 'gecko-dev', commit_sha, {
+            'state': 'success',
+        })
+
+    def get_commit(self, mercurial_commit):
+        url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s'
+
+        def get_mapped():
+            r = requests.get(url % mercurial_commit)
+
+            if r.status_code == requests.codes.ok:
+                return r.text.split(' ')[0]
+
+            return None
+
+        ret = wait_until(get_mapped)
+        if ret is None:
+            raise Exception('Mercurial commit is not available yet on mozilla/gecko-dev.')
+        return ret
+
+    def update_codecoveragereports_repo(self):
+        run_check(['git', 'config', '--global', 'http.postBuffer', '12M'])
+        run_check(['git', 'config', '--global', 'user.email', 'report@upload.it'])
+        run_check(['git', 'config', '--global', 'user.name', 'Report Uploader'])
+        repo_url = 'https://%s:%s@github.com/marco-c/code-coverage-reports' % (self.gecko_dev_user, self.gecko_dev_pwd)
+        run_check(['git', 'init'])
+        run_check(['git', 'add', '*'])
+        run_check(['git', 'commit', '-m', 'Coverage reports upload'])
+        retry(lambda: run_check(['git', 'push', repo_url, 'master', '--force']))

--- a/src/shipit_code_coverage/tests/test_artifacts.py
+++ b/src/shipit_code_coverage/tests/test_artifacts.py
@@ -2,7 +2,7 @@
 
 import os
 from shipit_code_coverage import utils
-from shipit_code_coverage.codecov import CodeCov
+from shipit_code_coverage.artifacts import ArtifactsHandler
 
 
 FILES = ['ccov-artifacts/%s' % f for f in [
@@ -22,8 +22,8 @@ def test_get_chunks():
     for f in FILES:
         open(f, 'w')
 
-    c = CodeCov(None, 'ccov-artifacts', '', '', '', '', None, None)
-    assert set(c.get_chunks()) == set([
+    a = ArtifactsHandler([], [])
+    assert set(a.get_chunks()) == set([
         'mochitest-1', 'mochitest-2', 'xpcshell-3', 'xpcshell-7',
         'cppunit', 'firefox-ui-functional-remote',
     ])
@@ -38,17 +38,17 @@ def test_get_coverage_artifacts():
     for f in FILES:
         open(f, 'w')
 
-    c = CodeCov(None, 'ccov-artifacts', '', '', '', '', None, None)
-    assert set(c.get_coverage_artifacts()) == set(FILES)
-    assert set(c.get_coverage_artifacts(suite='mochitest')) == set([
+    a = ArtifactsHandler([], [])
+    assert set(a.get_coverage_artifacts()) == set(FILES)
+    assert set(a.get_coverage_artifacts(suite='mochitest')) == set([
         'ccov-artifacts/windows_mochitest-1_code-coverage-jsvm.info',
         'ccov-artifacts/linux_mochitest-2_code-coverage-grcov.zip'
     ])
-    assert set(c.get_coverage_artifacts(chunk='xpcshell-7')) == set([
+    assert set(a.get_coverage_artifacts(chunk='xpcshell-7')) == set([
         'ccov-artifacts/windows_xpcshell-7_code-coverage-jsvm.info',
         'ccov-artifacts/linux_xpcshell-7_code-coverage-grcov.zip'
     ])
-    assert set(c.get_coverage_artifacts(chunk='cppunit')) == set([
+    assert set(a.get_coverage_artifacts(chunk='cppunit')) == set([
         'ccov-artifacts/windows_cppunit_code-coverage-grcov.zip'
     ])
 


### PR DESCRIPTION
The codecov.py module was getting too big, so I've moved artifacts- and github-related code to separate modules.