### PR TITLE
shipit_code_coverage: Reduce waiting times to 30 seconds

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/utils.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/utils.py
@@ -6,7 +6,7 @@ import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 
 
-def wait_until(operation, timeout=30, interval=60):
+def wait_until(operation, timeout=30, interval=30):
     elapsed = 0
     while elapsed < timeout:
         ret = operation()
@@ -18,7 +18,7 @@ def wait_until(operation, timeout=30, interval=60):
     return None
 
 
-def retry(operation, retries=5, wait_between_retries=120):
+def retry(operation, retries=5, wait_between_retries=30):
     successful = False
     while not successful and retries > 0:
         try:


### PR DESCRIPTION
Fixes #771.

I will monitor failure rates to see if 30 seconds is too short.