### PR TITLE
shipit_pulse_listener: Retry retrieving coverage build multiple times before failing and fail without throwing exceptions

### DIFF
--- a/lib/cli_common/cli_common/utils.py
+++ b/lib/cli_common/cli_common/utils.py
@@ -19,15 +19,14 @@ def wait_until(operation, timeout=30, interval=30):
 
 
 def retry(operation, retries=5, wait_between_retries=30):
-    successful = False
-    while not successful and retries > 0:
+    while True:
         try:
-            operation()
-            successful = True
-        except:
+            return operation()
+        except Exception:
             retries -= 1
+            if retries == 0:
+                raise
             time.sleep(wait_between_retries)
-    return successful
 
 
 def mkdir(path):

--- a/lib/cli_common/cli_common/utils.py
+++ b/lib/cli_common/cli_common/utils.py
@@ -34,7 +34,7 @@ def mkdir(path):
         os.mkdir(path)
     except OSError as e:
         if e.errno != errno.EEXIST:
-            raise e
+            raise
 
 
 class ThreadPoolExecutorResult(ThreadPoolExecutor):

--- a/lib/cli_common/tests/test_utils.py
+++ b/lib/cli_common/tests/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from shipit_code_coverage import utils
+from cli_common import utils
 import time
 
 
@@ -28,9 +28,13 @@ def test_wait_until():
 
 
 def test_retry():
-    assert utils.retry(lambda: True)
-    assert utils.retry(lambda: False)
-    assert not utils.retry(do_raise, wait_between_retries=0)
+    assert utils.retry(lambda: True) is True
+    assert utils.retry(lambda: False) is False
+    try:
+        utils.retry(do_raise, wait_between_retries=0)
+        assert False
+    except Exception:
+        pass
 
     i = {}
 
@@ -41,7 +45,7 @@ def test_retry():
             i['tried'] = True
             raise Exception('Please try again.')
 
-    assert utils.retry(try_twice, wait_between_retries=0)
+    assert utils.retry(try_twice, wait_between_retries=0) is None
 
 
 def test_threadpoolexecutorresult():
@@ -55,7 +59,7 @@ def test_threadpoolexecutorresult():
             executor.submit(lambda: True)
             executor.submit(do_raise)
         assert False
-    except:
+    except Exception:
         assert True
 
     # Tast that ThreadPoolExecutorResult's context returns as soon as a task fails.
@@ -65,7 +69,7 @@ def test_threadpoolexecutorresult():
             executor.submit(lambda: time.sleep(5))
             executor.submit(do_raise)
         assert False
-    except:
+    except Exception:
         assert time.time() - now < 2
 
     # Test that futures that were not scheduled yet are cancelled.
@@ -78,7 +82,7 @@ def test_threadpoolexecutorresult():
             f5 = executor.submit(lambda: time.sleep(1))
             f6 = executor.submit(lambda: time.sleep(1))
         assert False
-    except:
+    except Exception:
         assert f1.done() and not f1.cancelled()
         assert f2.exception() is not None
         # Not enough time to cancel the third future, scheduled right after the one which raises an exception.

--- a/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
@@ -2,9 +2,9 @@
 import os
 
 from cli_common.log import get_logger
+from cli_common.utils import mkdir, ThreadPoolExecutorResult
 
 from shipit_code_coverage import taskcluster
-from shipit_code_coverage.utils import mkdir, ThreadPoolExecutorResult
 
 
 logger = get_logger(__name__)

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -11,13 +11,13 @@ import sqlite3
 
 from cli_common.log import get_logger
 from cli_common.command import run_check
+from cli_common.utils import mkdir, retry, ThreadPoolExecutorResult
 
 from shipit_code_coverage import taskcluster, uploader
 from shipit_code_coverage.artifacts import ArtifactsHandler
 from shipit_code_coverage.github import GitHubUtils
 from shipit_code_coverage.notifier import Notifier
 from shipit_code_coverage.secrets import secrets
-from shipit_code_coverage.utils import mkdir, retry, ThreadPoolExecutorResult
 
 
 logger = get_logger(__name__)
@@ -130,7 +130,7 @@ class CodeCov(object):
 
             hg.update(rev=revision, clean=True)
 
-        retry(lambda: do_clone())
+        retry(do_clone)
 
         logger.info('mozilla-central cloned')
 

--- a/src/shipit_code_coverage/shipit_code_coverage/github.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/github.py
@@ -4,9 +4,9 @@ import requests
 
 from cli_common.command import run_check
 from cli_common.taskcluster import get_service
+from cli_common.utils import wait_until, retry
 
 from shipit_code_coverage.secrets import secrets
-from shipit_code_coverage.utils import wait_until, retry
 
 
 class GitHubUtils(object):

--- a/src/shipit_code_coverage/shipit_code_coverage/notifier.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/notifier.py
@@ -4,9 +4,9 @@ import requests
 
 from cli_common.log import get_logger
 from cli_common.taskcluster import get_service
+from cli_common.utils import wait_until
 
 from shipit_code_coverage.secrets import secrets
-from shipit_code_coverage.utils import wait_until
 
 
 logger = get_logger(__name__)

--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -4,7 +4,7 @@ import shutil
 from zipfile import BadZipFile, is_zipfile
 import requests
 
-from shipit_code_coverage.utils import retry
+from cli_common.utils import retry
 
 index_base = 'https://index.taskcluster.net/v1/'
 queue_base = 'https://queue.taskcluster.net/v1/'
@@ -84,8 +84,7 @@ def download_artifact(artifact_path, task_id, artifact_name):
         if artifact_path.endswith('.zip') and not is_zipfile(artifact_path):
             raise BadZipFile('File is not a zip file')
 
-    if not retry(perform_download):
-        raise Exception('Failed downloading artifact in %s' % artifact_path)
+    retry(perform_download)
 
 
 TEST_PLATFORMS = ['test-linux64-ccov/opt', 'test-windows10-64-ccov/debug']

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -3,7 +3,8 @@ import gzip
 import requests
 
 from cli_common.log import get_logger
-from shipit_code_coverage import utils
+from cli_common import utils
+
 from shipit_code_coverage.secrets import secrets
 
 

--- a/src/shipit_code_coverage/tests/test_artifacts.py
+++ b/src/shipit_code_coverage/tests/test_artifacts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-from shipit_code_coverage import utils
+from cli_common import utils
 from shipit_code_coverage.artifacts import ArtifactsHandler
 
 

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -262,6 +262,7 @@ class HookCodeCoverage(PulseHook):
             r = requests.get(list_url, params={
                 'limit': 200
             })
+            r.raise_for_status()
             reply = r.json()
             task = maybe_trigger(reply['tasks'])
 
@@ -270,6 +271,7 @@ class HookCodeCoverage(PulseHook):
                     'limit': 200,
                     'continuationToken': reply['continuationToken']
                 })
+                r.raise_for_status()
                 reply = r.json()
                 task = maybe_trigger(reply['tasks'])
 

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from cli_common.pulse import run_consumer
 from cli_common.log import get_logger
+from cli_common.utils import retry
 from shipit_pulse_listener.hook import Hook, PulseHook
 from shipit_pulse_listener import task_monitoring
 import requests
@@ -255,23 +256,27 @@ class HookCodeCoverage(PulseHook):
 
             return None
 
-        list_url = 'https://queue.taskcluster.net/v1/task-group/' + group_id + '/list'
-
-        r = requests.get(list_url, params={
-            'limit': 200
-        })
-        reply = r.json()
-        task = maybe_trigger(reply['tasks'])
-
-        while task is None and 'continuationToken' in reply:
-            r = requests.get(list_url, params={
-                'limit': 200,
-                'continuationToken': reply['continuationToken']
+        def retrieve_coverage_task():
+            r = requests.get('https://queue.taskcluster.net/v1/task-group/{}/list'.format(group_id), params={
+                'limit': 200
             })
             reply = r.json()
             task = maybe_trigger(reply['tasks'])
 
-        return task
+            while task is None and 'continuationToken' in reply:
+                r = requests.get(list_url, params={
+                    'limit': 200,
+                    'continuationToken': reply['continuationToken']
+                })
+                reply = r.json()
+                task = maybe_trigger(reply['tasks'])
+
+            return task
+
+        try:
+            return retry(retrieve_coverage_task)
+        except Exception:
+            return None
 
     def parse(self, body):
         '''

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -256,8 +256,10 @@ class HookCodeCoverage(PulseHook):
 
             return None
 
+        list_url = 'https://queue.taskcluster.net/v1/task-group/{}/list'.format(group_id)
+
         def retrieve_coverage_task():
-            r = requests.get('https://queue.taskcluster.net/v1/task-group/{}/list'.format(group_id), params={
+            r = requests.get(list_url, params={
                 'limit': 200
             })
             reply = r.json()


### PR DESCRIPTION
Fixes #848.