### PR TITLE
shipit_code_coverage: Make task triggered by the cron use the latest coverage build with finished tests

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
@@ -12,8 +12,7 @@ from shipit_code_coverage.utils import mkdir, ThreadPoolExecutorResult
 logger = get_logger(__name__)
 
 
-FINISHED_STATUSES = ['completed', 'failed', 'exception']
-ALL_STATUSES = FINISHED_STATUSES + ['unscheduled', 'pending', 'running']
+ALL_STATUSES = ['completed', 'failed', 'exception', 'unscheduled', 'pending', 'running']
 STATUS_VALUE = {
     'exception': 1,
     'failed': 2,
@@ -82,10 +81,6 @@ class ArtifactsHandler(object):
     def download(self, test_task):
         status = test_task['status']['state']
         assert status in ALL_STATUSES
-        while status not in FINISHED_STATUSES:
-            time.sleep(60)
-            status = taskcluster.get_task_status(test_task['status']['taskId'])['status']['state']
-            assert status in ALL_STATUSES
 
         chunk_name = taskcluster.get_chunk(test_task['task']['metadata']['name'])
         platform_name = taskcluster.get_platform(test_task['task']['metadata']['name'])

--- a/src/shipit_code_coverage/shipit_code_coverage/github.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/github.py
@@ -44,7 +44,7 @@ class GitHubUtils(object):
         def get_commit():
             r = requests.get('https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/hg/%s' % mercurial_commit)
 
-            if r.status_code == requests.codes.ok:
+            if r.ok:
                 return r.text.split(' ')[0]
 
             return None
@@ -58,7 +58,7 @@ class GitHubUtils(object):
         def get_commit():
             r = requests.get('https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/%s' % github_commit)
 
-            if r.status_code == requests.codes.ok:
+            if r.ok:
                 return r.text.split(' ')[1]
 
             return None

--- a/src/shipit_code_coverage/shipit_code_coverage/github.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/github.py
@@ -54,6 +54,20 @@ class GitHubUtils(object):
             raise Exception('Mercurial commit is not available yet on mozilla/gecko-dev.')
         return ret
 
+    def get_mercurial(self, github_commit):
+        def get_commit():
+            r = requests.get('https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/%s' % github_commit)
+
+            if r.status_code == requests.codes.ok:
+                return r.text.split(' ')[1]
+
+            return None
+
+        ret = wait_until(get_commit)
+        if ret is None:
+            raise Exception('Failed mapping git commit to mercurial commit.')
+        return ret
+
     def update_codecoveragereports_repo(self):
         if self.gecko_dev_user is None or self.gecko_dev_pwd is None:
             return

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -61,6 +61,12 @@ def codecov(data, commit_sha, flags=None):
         raise Exception('Failure to upload data to S3. Response [%s]: %s' % (r.status_code, r.text))
 
 
+def get_latest_codecov():
+    r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev?access_token={}'.format(secrets[secrets.CODECOV_ACCESS_TOKEN]))
+    r.raise_for_status()
+    return r.json()['commit']['commitid']
+
+
 def codecov_wait(commit):
     def check_codecov_job():
         r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev/commit/{}?access_token={}'.format(commit, secrets[secrets.CODECOV_ACCESS_TOKEN]))


### PR DESCRIPTION
Fixes #813

This way, we don't have to worry about test tasks that haven't finished yet.