### PR TITLE
shipit_uplift: Return 500 when coverage for a file couldn't be retrieved

### DIFF
--- a/src/shipit_uplift/settings.py
+++ b/src/shipit_uplift/settings.py
@@ -24,7 +24,7 @@ required = [
     'AUTH_CLIENT_SECRET',
     'AUTH_REDIRECT_URI',
     'REDIS_URL',
-    'CODECOV_TOKEN',
+    'CODECOV_ACCESS_TOKEN',
 ]
 
 secrets = cli_common.taskcluster.get_secrets(

--- a/src/shipit_uplift/shipit_uplift/api.py
+++ b/src/shipit_uplift/shipit_uplift/api.py
@@ -389,7 +389,12 @@ def coverage_by_dir(path=''):
 
 def coverage_for_file(changeset, path):
     changeset = changeset[:12]
-    return coverage_for_file_impl.generate(changeset, path)
+    try:
+        return coverage_for_file_impl.generate(changeset, path)
+    except Exception as e:
+        return {
+            'error': str(e)
+        }, 500
 
 
 def coverage_by_changeset(changeset):
@@ -405,7 +410,7 @@ def coverage_by_changeset(changeset):
 
     if job.exc_info is not None:
         return {
-          'error': str(job.exc_info)
+            'error': str(job.exc_info)
         }, 500
 
     return '', 202


### PR DESCRIPTION
This PR also updates the name of the secret from CODECOV_TOKEN to CODECOV_ACCESS_TOKEN (it was already changed, but I forgot to update settings.py too).