### PR TITLE
releng_frontend: Remove Mac OS X Static Analysis build and clarify win32 mingw32 description

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -84,7 +84,7 @@
                 <label><input type="checkbox" name="platform" value="win32-st-an">win32 static analysis</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="win32-mingw32">win32 mingw32</label> <span class="info">(debug only, no tests)</span>
+                <label><input type="checkbox" name="platform" value="win32-mingw32">win32 mingw32</label> <span class="info">(no tests)</span>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="win64">win64</label>

--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -72,9 +72,6 @@
                 <label><input type="checkbox" name="platform" value="macosx64">macosx64</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="macosx64-st-an">macosx64 static analysis</label>
-            </li>
-            <li>
                 <label><input type="checkbox" name="platform" value="win32">win32</label>
             </li>
             <li>


### PR DESCRIPTION
Regarding the Mac OSX Static Analysis one: https://bugzilla.mozilla.org/show_bug.cgi?id=1411408