### PR TITLE
shipit_uplift: Use .format instead of %

### DIFF
--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -28,7 +28,7 @@ def generate(changeset):
 
         # Use hg annotate to report lines in their correct positions and to avoid
         # reporting lines that have been modified by a successive patch in the same push.
-        r = requests.get('https://hg.mozilla.org/mozilla-central/json-annotate/%s/%s' % (build_changeset, path))
+        r = requests.get('https://hg.mozilla.org/mozilla-central/json-annotate/{}/{}'.format(build_changeset, path))
         data = r.json()
         if 'not found in manifest' in data:
             # The file was removed.

--- a/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_dir_impl.py
@@ -11,8 +11,8 @@ from shipit_uplift.coverage import coverage_service
 
 
 def get_mercurial_commit(github_commit):
-    url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/%s'
-    r = requests.get(url % github_commit)
+    url = 'https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/{}'
+    r = requests.get(url.format(github_commit))
 
     return r.text.split(' ')[1]
 


### PR DESCRIPTION
My last PR https://github.com/mozilla-releng/services/pull/864 broke some of the `.format` calls. This made  `get /coverage/changeset/{changeset}` and other endpoints always return 500.

This will be in WIP until I test these changes properly.

Fixes #839
