### PR TITLE
shipit_uplift: Switch to using async IO for coverage endpoints

### DIFF
--- a/lib/backend_common/requirements-dev.txt
+++ b/lib/backend_common/requirements-dev.txt
@@ -23,4 +23,4 @@ mohawk
 python-dateutil<2.7.0,>=2.1
 python-jose
 requests
-taskcluster<3.0.0
+taskcluster

--- a/lib/backend_common/requirements-extra.json
+++ b/lib/backend_common/requirements-extra.json
@@ -26,7 +26,7 @@
         "SQLAlchemy",
         "itsdangerous",
         "mozilla-cli-common[log]",
-        "taskcluster<3.0.0"
+        "taskcluster"
     ],
     "auth0": [
         "Flask",

--- a/lib/cli_common/requirements-dev.txt
+++ b/lib/cli_common/requirements-dev.txt
@@ -28,4 +28,4 @@ python-dateutil<2.7.0,>=2.1
 python-hglib
 raven
 structlog
-taskcluster<3.0.0
+taskcluster

--- a/lib/cli_common/requirements-extra.json
+++ b/lib/cli_common/requirements-extra.json
@@ -36,6 +36,6 @@
         "mozdef-client",
         "raven",
         "structlog",
-        "taskcluster<3.0.0"
+        "taskcluster"
     ]
 }

--- a/lib/please_cli/requirements.txt
+++ b/lib/please_cli/requirements.txt
@@ -8,4 +8,4 @@ https://github.com/garbas/push/archive/9883706635f1b145bff93d6490b2d9c270d3f674.
 mozdef-client
 requests
 slugid
-taskcluster<3.0.0
+taskcluster

--- a/src/shipit_uplift/requirements-dev.txt
+++ b/src/shipit_uplift/requirements-dev.txt
@@ -1,1 +1,3 @@
 -r ./../../lib/backend_common/requirements-dev.txt
+
+aresponses

--- a/src/shipit_uplift/requirements.nix
+++ b/src/shipit_uplift/requirements.nix
@@ -314,12 +314,13 @@ let
     };
 
     "aiohttp" = python.mkDerivation {
-      name = "aiohttp-2.3.10";
-      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/c0/b9/853b158f5cb5d218daaff0fb0dbc2bd7de45b2c6c5f563dff0ee530ec52a/aiohttp-2.3.10.tar.gz"; sha256 = "8adda6583ba438a4c70693374e10b60168663ffa6564c5c75d3c7a9055290964"; };
+      name = "aiohttp-3.1.2";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/fa/24/8f03b4d839730bf621b57f51d70c5602b9ea6598c01d6aafe786f41fecff/aiohttp-3.1.2.tar.gz"; sha256 = "df49fe4452a942e0031174c78917f9926d122d4603bf56bae4591639f2a3dc6a"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [
       self."async-timeout"
+      self."attrs"
       self."chardet"
       self."idna-ssl"
       self."multidict"
@@ -365,9 +366,38 @@ let
       };
     };
 
+    "aresponses" = python.mkDerivation {
+      name = "aresponses-1.0.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/62/41/a915f9fbe3ea896c49ca6f0f371c32b9b817703fd5829dbc641e58a242a0/aresponses-1.0.0.tar.gz"; sha256 = "0v2gaz1y6gr6g9n6zclscz02yz0yss6lmramdvmp2har6cdc5dja"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."aiohttp"
+      self."pytest-asyncio"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/circleup/aresponses";
+        license = "";
+        description = "Asyncio testing server. Similar to the responses library used for 'requests'";
+      };
+    };
+
+    "async-lru" = python.mkDerivation {
+      name = "async-lru-1.0.1";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/30/fc/a9a15a5fc778c425320b31da972ea241b9d660f6c95f82a2f134704a96fe/async_lru-1.0.1.tar.gz"; sha256 = "ac1f7138b54d68570391615b1ff758e189ce2b841a16653aae1255f5be5d4d0b"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/wikibusiness/async_lru";
+        license = licenses.mit;
+        description = "Simple lru_cache for asyncio";
+      };
+    };
+
     "async-timeout" = python.mkDerivation {
-      name = "async-timeout-1.4.0";
-      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/6f/cc/ff80612164fe68bf97767052c5c783a033165df7d47a41ae5c1cc5ea480b/async-timeout-1.4.0.tar.gz"; sha256 = "983891535b1eca6ba82b9df671c8abff53c804fce3fa630058da5bbbda500340"; };
+      name = "async-timeout-2.0.1";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/23/6d/e37be168272b7a499111d0ed14940da80644d21b201e27980892c7125abb/async-timeout-2.0.1.tar.gz"; sha256 = "00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [ ];
@@ -1459,6 +1489,22 @@ let
       };
     };
 
+    "pytest-asyncio" = python.mkDerivation {
+      name = "pytest-asyncio-0.8.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/c9/28/032baa7ba981928ec31faeb700b19fd7d3434bedff6aaff30b2e630dd82d/pytest-asyncio-0.8.0.tar.gz"; sha256 = "f32804bb58a66e13a3eda11f8942a71b1b6a30466b0d2ffe9214787aab0e172e"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."coverage"
+      self."pytest"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/pytest-dev/pytest-asyncio";
+        license = licenses.asl20;
+        description = "Pytest support for asyncio.";
+      };
+    };
+
     "pytest-cov" = python.mkDerivation {
       name = "pytest-cov-2.5.1";
       src = pkgs.fetchurl { url = "https://pypi.python.org/packages/24/b4/7290d65b2f3633db51393bdf8ae66309b37620bc3ec116c5e357e3e37238/pytest-cov-2.5.1.tar.gz"; sha256 = "03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"; };
@@ -1759,8 +1805,8 @@ let
     };
 
     "taskcluster" = python.mkDerivation {
-      name = "taskcluster-2.1.3";
-      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/9e/c6/a94dc47135d7516f6bf1b877079a08ffa4a420d5be2c39c2fa3d78f28875/taskcluster-2.1.3.tar.gz"; sha256 = "5bc6be5d59bd9a199b445db650081b9a8b7a8f436667172f9623bb34aff97556"; };
+      name = "taskcluster-3.0.0";
+      src = pkgs.fetchurl { url = "https://pypi.python.org/packages/90/77/8dca8f65f53a299f27a4154cd586dc06a4214008f2f21de062e85882eceb/taskcluster-3.0.0.tar.gz"; sha256 = "e99b11496ad3586c0a4295dc6a2a68534e93037ddc20b0b380e90908d21f1c43"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [

--- a/src/shipit_uplift/requirements.txt
+++ b/src/shipit_uplift/requirements.txt
@@ -1,9 +1,10 @@
 -e ./../../lib/cli_common[taskcluster,log] #egg=mozilla-cli-common
 -e ./../../lib/backend_common[log,security,cors,api,auth,db,cache] #egg=mozilla-backend-common
 
+aiohttp
+async-lru
 cachetools
 redis
 rq
-
 gunicorn
 psycopg2

--- a/src/shipit_uplift/requirements_frozen.txt
+++ b/src/shipit_uplift/requirements_frozen.txt
@@ -1,8 +1,10 @@
 aioamqp==0.10.0
-aiohttp==2.3.10
+aiohttp==3.1.2
 alembic==0.9.9
 amqp==2.2.2
-async-timeout==1.4.0
+aresponses==0.4.0
+async-lru==1.0.1
+async-timeout==2.0.1
 attrs==17.4.0
 backcall==0.1.0
 blinker==1.4
@@ -85,6 +87,7 @@ pycryptodome==3.6.0
 pyflakes==1.6.0
 Pygments==2.2.0
 pytest==3.5.0
+pytest-asyncio==0.8.0
 pytest-cov==2.5.1
 python-dateutil==2.6.1
 python-editor==1.0.3
@@ -106,7 +109,7 @@ slugid==1.0.7
 SQLAlchemy==1.2.6
 structlog==18.1.0
 swagger-spec-validator==2.1.0
-taskcluster==2.1.3
+taskcluster==3.0.0
 testfixtures==6.0.0
 traitlets==4.3.2
 typed-ast==1.1.0

--- a/src/shipit_uplift/shipit_uplift/api.py
+++ b/src/shipit_uplift/shipit_uplift/api.py
@@ -404,7 +404,12 @@ def coverage_by_changeset(changeset):
 
     if job is None:
         RESULT_TTL = 2 * 24 * 60 * 60
-        job = q.enqueue(coverage_by_changeset_impl.generate, changeset, job_id=changeset, result_ttl=RESULT_TTL)
+        job = q.enqueue(
+            lambda c: asyncio.get_event_loop().run_until_complete(coverage_by_changeset_impl.generate(c)),
+            changeset,
+            job_id=changeset,
+            result_ttl=RESULT_TTL
+        )
 
     if job.result is not None:
         return job.result, 200

--- a/src/shipit_uplift/shipit_uplift/api.py
+++ b/src/shipit_uplift/shipit_uplift/api.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import asyncio
 import pickle
 
 from flask import abort
@@ -429,10 +430,4 @@ def coverage_supported_extensions():
 
 
 def coverage_latest():
-    latest_rev, previous_rev = coverage.coverage_service.get_latest_build()
-    latest_pushid = coverage.get_changeset_data(latest_rev)['push']
-    return {
-      'latest_pushid': latest_pushid,
-      'latest_rev': latest_rev,
-      'previous_rev': previous_rev,
-    }
+    return asyncio.get_event_loop().run_until_complete(coverage.get_latest_build_info())

--- a/src/shipit_uplift/shipit_uplift/api.py
+++ b/src/shipit_uplift/shipit_uplift/api.py
@@ -390,7 +390,7 @@ def create_patch_status(bugzilla_id):
 def coverage_for_file(changeset, path):
     changeset = changeset[:12]
     try:
-        return coverage_for_file_impl.generate(changeset, path)
+        return asyncio.get_event_loop().run_until_complete(coverage_for_file_impl.generate(changeset, path))
     except Exception as e:
         return {
             'error': str(e)

--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -226,6 +226,16 @@ async def get_coverage_build(changeset):
     assert False, 'Couldn\'t find a build after the changeset'
 
 
+async def get_latest_build_info():
+    latest_rev, previous_rev = await coverage_service.get_latest_build()
+    latest_pushid = (await get_changeset_data(latest_rev))['push']
+    return {
+      'latest_pushid': latest_pushid,
+      'latest_rev': latest_rev,
+      'previous_rev': previous_rev,
+    }
+
+
 COVERAGE_EXTENSIONS = [
     # C
     'c', 'h',

--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -182,17 +182,11 @@ async def get_pushes_changesets(push_id, push_id_end):
     if push_id not in push_to_changeset_cache:
         await get_pushes(push_id)
 
-    # TODO: With Python 3.6+, we will be able to yield from an async function.
-    # So we don't need to create a changesets list but we can yield each changeset
-    # in the loop.
-    changesets = []
     for i in range(push_id, push_id_end):
         if i not in push_to_changeset_cache:
             continue
 
-        changesets.append(push_to_changeset_cache[i])
-
-    return changesets
+        yield push_to_changeset_cache[i]
 
 
 async def get_changeset_data(changeset):
@@ -216,7 +210,7 @@ async def get_coverage_build(changeset):
     push_id = changeset_data['push']
 
     # Find the first coverage build after the changeset.
-    for build_changeset in (await get_pushes_changesets(push_id, push_id + 8)):
+    async for build_changeset in get_pushes_changesets(push_id, push_id + 8):
         try:
             overall = await coverage_service.get_coverage(build_changeset)
             return (changeset_data, build_changeset, overall)

--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -4,10 +4,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import asyncio
-import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor
 
-import requests
+import aiohttp
 
 from shipit_uplift.coverage import coverage_service
 from shipit_uplift.coverage import coverage_supported
@@ -15,12 +13,8 @@ from shipit_uplift.coverage import get_coverage_build
 from shipit_uplift.coverage import get_github_commit
 
 
-def generate(changeset):
-    '''
-    This function generates a report containing the coverage information of the diff
-    introduced by a changeset.
-    '''
-    changeset_data, build_changeset, overall = get_coverage_build(changeset)
+async def retrieve_all(loop, changeset):
+    changeset_data, build_changeset, overall = await get_coverage_build(changeset)
     if 'merge' in changeset_data:
         raise Exception('Retrieving coverage for merge commits is not supported.')
 
@@ -31,21 +25,21 @@ def generate(changeset):
             return None
 
         # Retrieve annotate data.
-        annotate_future = loop.run_in_executor(None, requests.get, 'https://hg.mozilla.org/mozilla-central/json-annotate/{}/{}'.format(build_changeset, path))
+        async with aiohttp.request('GET', 'https://hg.mozilla.org/mozilla-central/json-annotate/{}/{}'.format(build_changeset, path)) as r:
+            annotate_future = r.json()
 
-        # Retrieve coverage data.
-        coverage_future = loop.run_in_executor(None, coverage_service.get_file_coverage, build_changeset, path)
+            # Retrieve coverage data.
+            coverage_future = coverage_service.get_file_coverage(build_changeset, path)
 
-        # Use hg annotate to report lines in their correct positions and to avoid
-        # reporting lines that have been modified by a successive patch in the same push.
-        data = (await annotate_future).json()
-        if 'not found in manifest' in data:
-            # The file was removed.
-            return None
-        annotate = data['annotate']
+            # Use hg annotate to report lines in their correct positions and to avoid
+            # reporting lines that have been modified by a successive patch in the same push.
+            data = await annotate_future
+            if 'not found in manifest' in data:
+                # The file was removed.
+                return None
+            annotate = data['annotate']
 
-        # Retrieve coverage of added lines.
-        coverage = await coverage_future
+            coverage = await coverage_future
 
         # If we don't have coverage for this file, we skip it.
         if coverage is None:
@@ -79,26 +73,29 @@ def generate(changeset):
           'changes': changes,
         }
 
-    async def retrieve_all(loop):
-        futures = []
-        for path in changeset_data['files']:
-            futures.append(retrieve_coverage(loop, path))
+    futures = []
+    for path in changeset_data['files']:
+        futures.append(retrieve_coverage(loop, path))
 
-        diffs = []
-        for f in asyncio.as_completed(futures):
-            res = await f
-            if res is not None:
-                diffs.append(res)
-
-        return diffs
-
-    loop = asyncio.get_event_loop()
-    diffs = loop.run_until_complete(retrieve_all(loop))
+    diffs = []
+    for f in asyncio.as_completed(futures):
+        res = await f
+        if res is not None:
+            diffs.append(res)
 
     return {
         'build_changeset': build_changeset,
-        'git_build_changeset': get_github_commit(build_changeset),
+        'git_build_changeset': await get_github_commit(build_changeset),
         'overall_cur': overall['cur'],
         'overall_prev': overall['prev'],
         'diffs': diffs,
     }
+
+
+def generate(changeset):
+    '''
+    This function generates a report containing the coverage information of the diff
+    introduced by a changeset.
+    '''
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(retrieve_all(loop, changeset))

--- a/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_by_changeset_impl.py
@@ -37,7 +37,7 @@ def generate(changeset):
         if 'not found in manifest' in data:
             # The file was removed.
             return None
-        annotate = r.json()['annotate']
+        annotate = data['annotate']
 
         # Retrieve coverage of added lines.
         coverage = coverage_service.get_file_coverage(build_changeset, path)

--- a/src/shipit_uplift/shipit_uplift/coverage_for_file_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_for_file_impl.py
@@ -3,9 +3,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import asyncio
+
 from shipit_uplift.coverage import coverage_service
 from shipit_uplift.coverage import coverage_supported
 from shipit_uplift.coverage import get_coverage_build
+
+
+async def retrieve(changeset, path):
+    # If the file is not a source file, we can return early (as we already know
+    # we have no coverage information for it).
+    if not coverage_supported(path):
+        return {}
+
+    _, build_changeset, _ = await get_coverage_build(changeset)
+
+    coverage = await coverage_service.get_file_coverage(build_changeset, path)
+
+    return coverage if coverage is not None else {}
 
 
 def generate(changeset, path):
@@ -13,13 +28,4 @@ def generate(changeset, path):
     This function generates a report containing the coverage information for a given file
     at a given revision.
     '''
-    # If the file is not a source file, we can return early (as we already know
-    # we have no coverage information for it).
-    if not coverage_supported(path):
-        return {}
-
-    _, build_changeset, _ = get_coverage_build(changeset)
-
-    coverage = coverage_service.get_file_coverage(build_changeset, path)
-
-    return coverage if coverage is not None else {}
+    return asyncio.get_event_loop().run_until_complete(retrieve(changeset, path))

--- a/src/shipit_uplift/shipit_uplift/coverage_for_file_impl.py
+++ b/src/shipit_uplift/shipit_uplift/coverage_for_file_impl.py
@@ -3,14 +3,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import asyncio
-
 from shipit_uplift.coverage import coverage_service
 from shipit_uplift.coverage import coverage_supported
 from shipit_uplift.coverage import get_coverage_build
 
 
-async def retrieve(changeset, path):
+async def generate(changeset, path):
+    '''
+    This function generates a report containing the coverage information for a given file
+    at a given revision.
+    '''
     # If the file is not a source file, we can return early (as we already know
     # we have no coverage information for it).
     if not coverage_supported(path):
@@ -21,11 +23,3 @@ async def retrieve(changeset, path):
     coverage = await coverage_service.get_file_coverage(build_changeset, path)
 
     return coverage if coverage is not None else {}
-
-
-def generate(changeset, path):
-    '''
-    This function generates a report containing the coverage information for a given file
-    at a given revision.
-    '''
-    return asyncio.get_event_loop().run_until_complete(retrieve(changeset, path))

--- a/src/shipit_uplift/tests/test_coverage.py
+++ b/src/shipit_uplift/tests/test_coverage.py
@@ -33,10 +33,10 @@ async def test_coverage_latest(coverage_responses):
 
 
 @pytest.mark.asyncio
-async def test_coverage_by_changeset_impl(event_loop, coverage_responses, coverage_builds):
+async def test_coverage_by_changeset_impl(coverage_responses, coverage_builds):
     # Get changeset coverage information
     for changeset in coverage_builds['info']:
-        data = await coverage_by_changeset_impl.retrieve_all(event_loop, changeset)
+        data = await coverage_by_changeset_impl.generate(changeset)
         assert data == coverage_builds['info'][changeset]
 
 

--- a/src/shipit_uplift/tests/test_coverage.py
+++ b/src/shipit_uplift/tests/test_coverage.py
@@ -52,5 +52,5 @@ def test_coverage_summary_by_changeset_impl(coverage_builds):
 async def test_coverage_for_file_impl(coverage_responses, coverage_changeset_by_file):
     # Get code coverage information for a given file at a given changeset
     for file_coverage in coverage_changeset_by_file:
-        data = await coverage_for_file_impl.retrieve(file_coverage['changeset'], file_coverage['path'])
+        data = await coverage_for_file_impl.generate(file_coverage['changeset'], file_coverage['path'])
         assert data == file_coverage['data']


### PR DESCRIPTION
Fixes #856 and fixes #862.

We are blocked on updating to aiohttp 3 because of the Taskcluster library (https://github.com/taskcluster/taskcluster-client.py/issues/96). aiohttp 3 would be needed in order to do `async with aiohttp.request` without leaks.
If we can't upgrade to aiohttp 3 soon enough, we should switch to using a aiohttp session directly (#863).