### PR TITLE
Bug 1437116 - Change "full-user-credentials" scope to "taskcluster-credentials"

### DIFF
--- a/lib/backend_common/backend_common/auth0.py
+++ b/lib/backend_common/backend_common/auth0.py
@@ -130,7 +130,7 @@ def auth0_login():
     '''
     params = {
         'audience': 'login.taskcluster.net',
-        'scope': 'full-user-credentials openid',
+        'scope': 'taskcluster-credentials openid',
         'response_type': 'code',
         'client_id': flask.current_app.config.get('AUTH_CLIENT_ID'),
         'redirect_uri': flask.current_app.config.get('AUTH_REDIRECT_URI'),


### PR DESCRIPTION
If a user logs in for the first time in treeherder.mozilla.org, tools.taskcluster.net or https://mozilla-releng.net, they will get a prompt asking permission to access “full-user-credentials”. This is simply asking to access the user's taskcluster credentials but is a little bit scary and misleading. To that end, we are changing it to be `taskcluster-credentials`. Both taskcluster-tools[1] and treeherder[2] have been successfully switched to using `taskcluster-credentials`. Once we have this merged here, I will ask the IAM team to remove `full-user-credentials`.

[1] https://github.com/taskcluster/taskcluster-tools/pull/441
[2] https://github.com/mozilla/treeherder/pull/3227


