### PR TITLE
cli_common: Only log program name, to avoid Sentry ingoring too long messages

### DIFF
--- a/lib/cli_common/cli_common/command.py
+++ b/lib/cli_common/cli_common/command.py
@@ -82,8 +82,8 @@ def run_check(command, **kwargs):
             error=error,
         )
         raise click.ClickException(
-            'Command (`{}`) failed with code: {}.'.format(
-                command_as_string,
+            '`{}` failed with code: {}.'.format(
+                command[0],
                 returncode,
             )
         )

--- a/lib/cli_common/cli_common/command.py
+++ b/lib/cli_common/cli_common/command.py
@@ -26,6 +26,9 @@ def run(command, stream=False, handle_stream_line=None, log_command=True,
     else:
         command_as_string = ' ' .join(command)
 
+    if len(command) == 0:
+        raise click.ClickException('Can\'t run an empty command.')
+
     _kwargs = dict(
         stdin=subprocess.DEVNULL,  # no interactions
         stdout=subprocess.PIPE,

--- a/lib/cli_common/tests/test_command.py
+++ b/lib/cli_common/tests/test_command.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from cli_common import command
+import click
+import pytest
+
+
+def test_empty_command():
+    for param in [[], '']:
+        for func in ['run', 'run_check']:
+            with pytest.raises(click.ClickException, message="Can\'t run an empty command."):
+                getattr(command, func)(param)


### PR DESCRIPTION
There's a `log.info` right before with more information, so we wouldn't lose anything here.