### PR TITLE
Use only OK Auth0 responses

### DIFF
--- a/lib/backend_common/backend_common/auth0.py
+++ b/lib/backend_common/backend_common/auth0.py
@@ -54,8 +54,8 @@ def mozilla_accept_token(render_errors=True):
         unmodified for later rendering.
     :type render_errors: bool
 
-    Side effects: flask.g gets the 'userinfo' attribute containing the data
-    from the response
+    Side effects: flask.g gets the 'userinfo' and 'access_token' attributes
+    containing the data from the response
 
     .. versionadded:: 1.0
     '''
@@ -72,7 +72,7 @@ def mozilla_accept_token(render_errors=True):
                 token = flask.request.args['access_token']
 
             url = auth0.client_secrets.get(
-                'userinfo_uri', 'https://auth.mozilla.auth0.com/userinfo')
+                'userinfo_uri', 'https://{}/userinfo'.format(flask.current_app.config.get('AUTH_DOMAIN')))
             payload = {'access_token': token}
             response = requests.get(url, params=payload)
 

--- a/lib/backend_common/backend_common/auth0.py
+++ b/lib/backend_common/backend_common/auth0.py
@@ -77,7 +77,7 @@ def mozilla_accept_token(render_errors=True):
             response = requests.get(url, params=payload)
 
             # Because auth0 returns http 200 even if the token is invalid.
-            if response.content == b'Unauthorized':
+            if response.content == b'Unauthorized' or not response.ok:
                 response_body = {'error': 'invalid_token',
                                  'error_description': str(response.content, 'utf-8')}
                 if render_errors:


### PR DESCRIPTION
It looks like Auth0 started setting proper response codes, at least I
hit 400 while hacking on something. This should handle the situation
when Auth0 API returns 400/500 errors