### PR TITLE
nix: Don't use 'reviewboard' mercurial extension

### DIFF
--- a/nix/tools/mercurial.nix
+++ b/nix/tools/mercurial.nix
@@ -36,7 +36,6 @@ in mercurial.overrideDerivation (old: {
     [extensions]
     purge =
     robustcheckout = ${hg_tools}/hgext/robustcheckout/__init__.py
-    reviewboard = ${hg_tools}/hgext/reviewboard/client.py
     EOF
   '';
 })


### PR DESCRIPTION
It is definitely unused in the code coverage project and as far as I can tell in the static analysis project too.
Sometimes it causes issues, such as:
```
    hglib.error.CommandError: (1, b'ensuring https://hg.mozilla.org/mozilla-central@tip is available at /cache/mozilla-central
    (existing repository shared store: /cache/mozilla-central-shared/8ba995b74e18334ab3707f27e9eb8f4e37ba3d29/.hg)
    (pulling to obtain tip)
    (purging working directory)', b'(using Mercurial 4.5)
    (remote resolved tip to bccdc684210431c233622650a91454c09f6af9eb; result is not deterministic)
    (revision already present locally; not pulling)
    ** Unknown exception encountered with possibly-broken third-party extension reviewboard
    ** which supports versions 4.2 of Mercurial.
    ** Please disable reviewboard and try your action again.
    ** If that fixes the bug please report it to https://bugzilla.mozilla.org/enter_bug.cgi?product=MozReview&component=Integration%3A%20Mercurial
    ** Python 2.7.14 (default, Sep 16 2017, 17:49:51) [GCC 7.3.0]
    ** Mercurial Distributed SCM (version 4.5)
    ** Extensions loaded: purge, robustcheckout, reviewboard, share
    Traceback (most recent call last):
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/bin/..hg-wrapped-wrapped", line 42, in <module>
        dispatch.run()
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 88, in run
        status = (dispatch(req) or 0) & 255
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 183, in dispatch
        ret = _runcatch(req)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 324, in _runcatch
        return _callcatch(ui, _runcatchfunc)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 332, in _callcatch
        return scmutil.callcatch(ui, func)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/scmutil.py", line 154, in callcatch
        return func()
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 314, in _runcatchfunc
        return _dispatch(req)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 918, in _dispatch
        cmdpats, cmdoptions)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 673, in runcommand
        ret = _runcommand(ui, options, cmd, d)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 926, in _runcommand
        return cmdfunc()
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/dispatch.py", line 915, in <lambda>
        d = lambda: util.checksignature(func)(ui, *args, **strcmdopt)
      File "/nix/store/yf3ay3k4gac75qak5w8bcd026c7k658m-mercurial-4.5/lib/python2.7/site-packages/mercurial/util.py", line 1195, in check
        return func(*args, **kwargs)
      File "/nix/store/57jg67mxm4nsspg1jwgqjpn5yq8kqgqn-mozilla-hg-tools/hgext/robustcheckout/__init__.py", line 239, in robustcheckout
        sparse_profile=sparseprofile)
      File "/nix/store/57jg67mxm4nsspg1jwgqjpn5yq8kqgqn-mozilla-hg-tools/hgext/robustcheckout/__init__.py", line 548, in _docheckout
        assert util.versiontuple(n=2) == (4, 3)
    AssertionError') 
```