### PR TITLE
shipit_code_coverage: Ignore not existing files in some cases

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -209,7 +209,8 @@ class CodeCov(object):
         else:
             mkdir('code-coverage-reports')
 
-            self.generate_suite_reports()
+            # XXX: Disabled as it is unused for now.
+            # self.generate_suite_reports()
 
             report_generators.zero_coverage(self.artifactsHandler.get())
 

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -124,7 +124,7 @@ class CodeCov(object):
             futures = {}
             for platform in ['linux', 'windows']:
                 for chunk in self.artifactsHandler.get_chunks():
-                    future = executor.submit(grcov.files_list, self.artifactsHandler.get(platform=platform, chunk=chunk))
+                    future = executor.submit(grcov.files_list, self.artifactsHandler.get(platform=platform, chunk=chunk), source_dir=self.repo_dir)
                     futures[future] = (platform, chunk)
 
             with sqlite3.connect('chunk_mapping.sqlite') as conn:

--- a/src/shipit_code_coverage/shipit_code_coverage/grcov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/grcov.py
@@ -27,6 +27,7 @@ def report(artifacts, source_dir=None, service_number=None, commit_sha='unused',
 
     if source_dir is not None:
         cmd.extend(['-s', source_dir])
+        cmd.append('--ignore-not-existing')
 
     cmd.extend(artifacts)
     cmd.extend(options)

--- a/src/shipit_code_coverage/tests/test_grcov.py
+++ b/src/shipit_code_coverage/tests/test_grcov.py
@@ -78,9 +78,10 @@ def test_report_multiple_artifacts(grcov_artifact, jsvm_artifact):
     assert set(['toolkit/components/osfile/osfile.jsm', 'js/src/jit/BitSet.cpp']) == set([sf['name'] for sf in report['source_files']])
 
 
-def test_report_source_dir(grcov_existing_file_artifact):
+def test_report_source_dir(grcov_artifact, grcov_existing_file_artifact):
     output = grcov.report([grcov_existing_file_artifact], source_dir=os.getcwd(), out_format='coveralls')
     report = json.loads(output.decode('utf-8'))
+    # When we pass the source directory to the report function, grcov ignores not-existing files.
     assert len(report['source_files']) == 1
     assert report['source_files'][0]['name'] == 'shipit_code_coverage/cli.py'
     # When we pass the source directory to grcov and the file exists, grcov can calculate its hash.


### PR DESCRIPTION
I had removed the parameter from #909, but then realized we actually want it in some cases (that is, in the cases where we also pass the source directory).

This PR also disables the suite reporting for now, since it is unused.