### PR TITLE
shipit-static-analysis: Support missing relative or absolute path in linter 

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -157,5 +157,5 @@ class MozLint(object):
         return [
             MozLintIssue(self.repo_dir, path, **issue)
             for p in (path, full_path)
-            for issue in payload[p]
+            for issue in payload.get(p, [])
         ]


### PR DESCRIPTION
Avoid crashing tasks like for bug https://reviewboard.mozilla.org/r/226050/