### PR TITLE
shipit-static-analysis: Use raw patch instead of mercurial revisions.

### DIFF
--- a/src/shipit_static_analysis/default.nix
+++ b/src/shipit_static_analysis/default.nix
@@ -81,7 +81,7 @@ let
     version = fileContents ./VERSION;
     src = filterSource ./. { inherit name; };
     buildInputs =
-      fromRequirementsFile ./requirements-dev.txt python.packages;
+      [ mercurial ] ++ fromRequirementsFile ./requirements-dev.txt python.packages;
     propagatedBuildInputs =
       fromRequirementsFile ./requirements.txt python.packages
       ++ [

--- a/src/shipit_static_analysis/shipit_static_analysis/cli.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/cli.py
@@ -111,6 +111,9 @@ def main(phabricator,
                 error=e,
             )
 
+            # Then raise to mark task as erroneous
+            raise
+
 
 if __name__ == '__main__':
     main()

--- a/src/shipit_static_analysis/shipit_static_analysis/config.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/config.py
@@ -11,6 +11,10 @@ import requests
 
 PROJECT_NAME = 'shipit-static-analysis'
 CONFIG_URL = 'https://hg.mozilla.org/mozilla-central/raw-file/tip/tools/clang-tidy/config.yaml'
+REPO_CENTRAL = b'https://hg.mozilla.org/mozilla-central'
+REPO_REVIEW = b'https://reviewboard-hg.mozilla.org/gecko'
+ARTIFACT_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/public/results/{diff_name}'
+
 
 logger = get_logger(__name__)
 

--- a/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
@@ -73,19 +73,14 @@ class PhabricatorReporter(Reporter):
             'Not found'
         return data[0]
 
-    def load_revision(self, phid):
+    def load_raw_diff(self, diff_id):
         '''
-        Find a differential revision details
-        Uses the old style API - only way to get a mercurial hash
+        Load the raw diff content
         '''
-        data = self.request(
-            'differential.query',
-            phids=[phid, ],
+        return self.request(
+            'differential.getrawdiff',
+            diffID=diff_id,
         )
-
-        assert len(data) == 1, \
-            'Not found'
-        return data[0]
 
     def publish(self, issues, revision, diff_url=None):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -83,9 +83,6 @@ class PhabricatorRevision(Revision):
         # Load diff details to get the diff revision
         diff = self.api.load_diff(self.diff_phid)
         self.diff_id = diff['id']
-        assert 'fields' in diff
-        self.phid = diff['fields']['revisionPHID']
-        assert self.phid.startswith('PHID-DREV')
 
     def __str__(self):
         return 'Phabricator #{} - {}'.format(self.diff_id, self.diff_phid)

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -13,16 +13,12 @@ from cli_common.log import get_logger
 from cli_common.command import run_check
 from shipit_static_analysis.clang.tidy import ClangTidy
 from shipit_static_analysis.clang.format import ClangFormat
-from shipit_static_analysis.config import settings
+from shipit_static_analysis.config import settings, REPO_CENTRAL, ARTIFACT_URL
 from shipit_static_analysis.lint import MozLint
 from shipit_static_analysis import CLANG_TIDY, CLANG_FORMAT, MOZLINT
 from shipit_static_analysis import stats
 
 logger = get_logger(__name__)
-
-REPO_CENTRAL = b'https://hg.mozilla.org/mozilla-central'
-REPO_REVIEW = b'https://reviewboard-hg.mozilla.org/gecko'
-ARTIFACT_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/public/results/{diff_name}'
 
 
 class Workflow(object):
@@ -92,8 +88,6 @@ class Workflow(object):
          * Run static analysis
          * Publish results
         '''
-        assert revision.mercurial is not None, \
-            'Cannot run without a mercurial revision'
 
         # Add log to find Taskcluster task in papertrail
         logger.info(
@@ -101,11 +95,11 @@ class Workflow(object):
             taskcluster_task=self.taskcluster_task_id,
             taskcluster_run=self.taskcluster_run_id,
             channel=settings.app_channel,
-            revision=revision,
+            revision=str(revision),
         )
         stats.api.event(
-            title='Static analysis on {} for {}'.format(settings.app_channel, revision.mercurial[:12]),
-            text='Task {} #{}\n{}'.format(self.taskcluster_task_id, self.taskcluster_run_id, revision),
+            title='Static analysis on {} for {}'.format(settings.app_channel, revision),
+            text='Task {} #{}'.format(self.taskcluster_task_id, self.taskcluster_run_id),
         )
         stats.api.increment('analysis')
 
@@ -119,14 +113,8 @@ class Workflow(object):
             # otherwise previous pull are there
             self.hg.update(rev=b'tip', clean=True)
 
-            # Pull revision from review
-            self.hg.pull(source=REPO_REVIEW, rev=revision.mercurial, update=True, force=True)
-
             # Update to the target revision
-            self.hg.update(rev=revision.mercurial, clean=True)
-
-            # Analyze files in revision
-            revision.analyze_files(self.hg)
+            revision.apply(self.repo_dir)
 
         with stats.api.timer('runtime.mach'):
             # Only run mach if revision has any C/C++ files
@@ -144,8 +132,9 @@ class Workflow(object):
                 logger.info('No clang files detected, skipping mach')
 
             # Setup python environment
+            # --setup has been removed, --list still triggers the setup
             logger.info('Mach lint setup...')
-            cmd = ['gecko-env', './mach', 'lint', '--setup']
+            cmd = ['gecko-env', './mach', 'lint', '--list']
             run_check(cmd, cwd=self.repo_dir)
 
         # Run static analysis through clang-tidy

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -119,8 +119,9 @@ class Workflow(object):
             self.hg.update(rev=self.tip, clean=True)
             logger.info('Set repo back to tip', rev=self.tip)
 
-            # Update to the target revision
-            revision.apply(self.repo_dir)
+            # Apply and analyze revision patch
+            revision.apply(self.hg)
+            revision.analyze_patch()
 
         with stats.api.timer('runtime.mach'):
             # Only run mach if revision has any C/C++ files

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -78,12 +78,7 @@ class Workflow(object):
             raise hglib.error.CommandError(cmd, proc.returncode, out, err)
 
         # Open new hg client
-        client = hglib.open(self.repo_dir)
-
-        # Save tip
-        self.tip = client.tip().node
-
-        return client
+        return hglib.open(self.repo_dir)
 
     def run(self, revision):
         '''
@@ -116,8 +111,8 @@ class Workflow(object):
         with stats.api.timer('runtime.mercurial'):
             # Force cleanup to reset tip
             # otherwise previous pull are there
-            self.hg.update(rev=self.tip, clean=True)
-            logger.info('Set repo back to tip', rev=self.tip)
+            self.hg.update(rev=b'tip', clean=True)
+            logger.info('Set repo back to tip', rev=self.hg.tip().node)
 
             # Apply and analyze revision patch
             revision.apply(self.hg)
@@ -139,7 +134,6 @@ class Workflow(object):
                 logger.info('No clang files detected, skipping mach')
 
             # Setup python environment
-            # --setup has been removed, --list still triggers the setup
             logger.info('Mach lint setup...')
             cmd = ['gecko-env', './mach', 'lint', '--list']
             run_check(cmd, cwd=self.repo_dir)

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -78,7 +78,12 @@ class Workflow(object):
             raise hglib.error.CommandError(cmd, proc.returncode, out, err)
 
         # Open new hg client
-        return hglib.open(self.repo_dir)
+        client = hglib.open(self.repo_dir)
+
+        # Save tip
+        self.tip = client.tip().node
+
+        return client
 
     def run(self, revision):
         '''
@@ -111,7 +116,8 @@ class Workflow(object):
         with stats.api.timer('runtime.mercurial'):
             # Force cleanup to reset tip
             # otherwise previous pull are there
-            self.hg.update(rev=b'tip', clean=True)
+            self.hg.update(rev=self.tip, clean=True)
+            logger.info('Set repo back to tip', rev=self.tip)
 
             # Update to the target revision
             revision.apply(self.repo_dir)

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -8,6 +8,7 @@ import itertools
 import httpretty
 import os.path
 import pytest
+import hglib
 import time
 import json
 import re
@@ -32,6 +33,30 @@ def mock_config():
     from shipit_static_analysis.config import settings
     settings.setup('test')
     return settings
+
+
+@pytest.fixture
+def mock_repository(tmpdir):
+    '''
+    Create a dummy mercurial repository
+    '''
+    # Init repo
+    repo_dir = str(tmpdir.mkdir('repo').realpath())
+    hglib.init(repo_dir)
+
+    # Init clean client
+    client = hglib.open(repo_dir)
+
+    # Add test.txt file
+    path = os.path.join(repo_dir, 'test.txt')
+    with open(path, 'w') as f:
+        f.write('Hello World')
+
+    # Initiall commit
+    client.add(path.encode('utf-8'))
+    client.commit(b'Hello World', user=b'Tester')
+
+    return client
 
 
 @pytest.fixture

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -46,11 +46,12 @@ def mock_repository(tmpdir):
 
     # Init clean client
     client = hglib.open(repo_dir)
+    client.directory = repo_dir
 
     # Add test.txt file
     path = os.path.join(repo_dir, 'test.txt')
     with open(path, 'w') as f:
-        f.write('Hello World')
+        f.write('Hello World\n')
 
     # Initiall commit
     client.add(path.encode('utf-8'))

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -161,6 +161,13 @@ def mock_phabricator():
         content_type='application/json',
     )
 
+    responses.add(
+        responses.POST,
+        'http://phabricator.test/api/differential.getrawdiff',
+        body=_response('diff_raw'),
+        content_type='application/json',
+    )
+
 
 @pytest.fixture(scope='session')
 def mock_stats(mock_config):

--- a/src/shipit_static_analysis/tests/mocks/phabricator_diff_raw.json
+++ b/src/shipit_static_analysis/tests/mocks/phabricator_diff_raw.json
@@ -1,5 +1,5 @@
 {
 	"error_code": null,
 	"error_info": null,
-	"result": "diff --git a/src/test.txt b/src/test.txt\nindex 557db03..5eb0bec 100644\n--- a/src/test.txt\n+++ b/src/test.txt\n@@ -1 +1,2 @@\n Hello World\n+Second line"
+	"result": "diff --git a/test.txt b/test.txt\nindex 557db03..5eb0bec 100644\n--- a/test.txt\n+++ b/test.txt\n@@ -1 +1,2 @@\n Hello World\n+Second line"
 }

--- a/src/shipit_static_analysis/tests/mocks/phabricator_diff_raw.json
+++ b/src/shipit_static_analysis/tests/mocks/phabricator_diff_raw.json
@@ -1,0 +1,5 @@
+{
+	"error_code": null,
+	"error_info": null,
+	"result": "diff --git a/src/test.txt b/src/test.txt\nindex 557db03..5eb0bec 100644\n--- a/src/test.txt\n+++ b/src/test.txt\n@@ -1 +1,2 @@\n Hello World\n+Second line"
+}

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import responses
+import os
 from parsepatch.patch import Patch
 
 
@@ -40,7 +41,10 @@ def test_phabricator(mock_phabricator, mock_repository):
     assert r.url == 'https://phabricator.test/PHID-DIFF-testABcd12/'
     assert r.build_diff_name() == 'PHID-DIFF-testABcd12-clang-format.diff'
     assert r.id == 51  # revision
-    assert r.phid == 'PHID-DREV-zzzzz'
+
+    # Check test.txt content
+    test_txt = os.path.join(mock_repository.directory, 'test.txt')
+    assert open(test_txt).read() == 'Hello World\n'
 
     # Load full patch
     assert r.patch is None
@@ -57,6 +61,9 @@ def test_phabricator(mock_phabricator, mock_repository):
             'new': False
         }
     }
+
+    # Check file is updated
+    assert open(test_txt).read() == 'Hello World\nSecond line\n'
 
 
 def test_clang_files(mock_revision):

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -21,7 +21,7 @@ def test_mozreview():
 
 
 @responses.activate
-def test_phabricator(mock_phabricator):
+def test_phabricator(mock_phabricator, mock_repository):
     '''
     Test a phabricator revision
     '''
@@ -43,12 +43,14 @@ def test_phabricator(mock_phabricator):
     assert r.phid == 'PHID-DREV-zzzzz'
 
     # Load full patch
-    raw_patch = r.load_raw_patch()
-    assert isinstance(raw_patch, str)
-    assert len(raw_patch.split('\n')) == 7
-    patch = Patch.parse_patch(raw_patch)
+    assert r.patch is None
+    r.apply(mock_repository)
+    assert r.patch is not None
+    assert isinstance(r.patch, str)
+    assert len(r.patch.split('\n')) == 7
+    patch = Patch.parse_patch(r.patch)
     assert patch == {
-        'src/test.txt': {
+        'test.txt': {
             'touched': [],
             'deleted': [],
             'added': [2],


### PR DESCRIPTION
Needed to support Phabricator's multiple modes (hgcm, gtcm, gttr)