### PR TITLE
shipit_code_coverage: Add source_dir parameter to files_list 

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/grcov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/grcov.py
@@ -35,7 +35,7 @@ def report(artifacts, source_dir=None, service_number=None, commit_sha='unused',
     return run_check(cmd)
 
 
-def files_list(artifacts):
+def files_list(artifacts, source_dir=None):
     options = ['--filter-covered', '--threads', '2']
-    files = report(artifacts, out_format='files', options=options)
+    files = report(artifacts, source_dir=source_dir, out_format='files', options=options)
     return files.decode('utf-8').splitlines()

--- a/src/shipit_code_coverage/tests/test_grcov.py
+++ b/src/shipit_code_coverage/tests/test_grcov.py
@@ -116,3 +116,8 @@ def test_report_options(grcov_artifact, jsvm_artifact):
 def test_files_list(grcov_artifact, grcov_uncovered_artifact):
     files = grcov.files_list([grcov_artifact, grcov_uncovered_artifact])
     assert set(files) == set(['js/src/jit/BitSet.cpp'])
+
+
+def test_files_list_source_dir(grcov_artifact, grcov_existing_file_artifact):
+    files = grcov.files_list([grcov_artifact, grcov_existing_file_artifact], source_dir=os.getcwd())
+    assert set(files) == set(['shipit_code_coverage/cli.py'])


### PR DESCRIPTION
It got lost in a refactoring, but codecov.py is using it for chunk_mapping generation (for which tests will be added soon).