### PR TITLE
Replace utils.wait_until by utils.retry (closes #854)

### DIFF
--- a/lib/cli_common/cli_common/utils.py
+++ b/lib/cli_common/cli_common/utils.py
@@ -6,18 +6,6 @@ import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 
 
-def wait_until(operation, timeout=30, interval=30):
-    elapsed = 0
-    while elapsed < timeout:
-        ret = operation()
-        if ret:
-            return ret
-        time.sleep(interval)
-        elapsed += 1
-
-    return None
-
-
 def retry(operation, retries=5, wait_between_retries=30):
     while True:
         try:

--- a/lib/cli_common/tests/test_utils.py
+++ b/lib/cli_common/tests/test_utils.py
@@ -9,25 +9,6 @@ def do_raise():
     raise Exception('Err')
 
 
-def test_wait_until():
-    assert utils.wait_until(lambda: False, 1, 1) is None
-    assert utils.wait_until(lambda: None, 1, 1) is None
-    assert utils.wait_until(lambda: '', 1, 1) is None
-    assert utils.wait_until(lambda: True, 1, 1) is not None
-    assert utils.wait_until(lambda: 'Prova', 1, 1) is not None
-
-    i = {}
-
-    def try_twice():
-        if 'tried' in i:
-            return True
-        else:
-            i['tried'] = True
-            return False
-
-    assert utils.wait_until(try_twice, 2, 1) is not None
-
-
 def test_retry():
     assert utils.retry(lambda: True) is True
     assert utils.retry(lambda: False) is False

--- a/src/shipit_code_coverage/shipit_code_coverage/github.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/github.py
@@ -4,7 +4,7 @@ import requests
 
 from cli_common.command import run_check
 from cli_common.taskcluster import get_service
-from cli_common.utils import wait_until, retry
+from cli_common.utils import retry
 
 from shipit_code_coverage.secrets import secrets
 
@@ -49,7 +49,7 @@ class GitHubUtils(object):
 
             return None
 
-        ret = wait_until(get_commit)
+        ret = retry(get_commit)
         if ret is None:
             raise Exception('Mercurial commit is not available yet on mozilla/gecko-dev.')
         return ret
@@ -63,7 +63,7 @@ class GitHubUtils(object):
 
             return None
 
-        ret = wait_until(get_commit)
+        ret = retry(get_commit)
         if ret is None:
             raise Exception('Failed mapping git commit to mercurial commit.')
         return ret

--- a/src/shipit_code_coverage/shipit_code_coverage/notifier.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/notifier.py
@@ -4,7 +4,6 @@ import requests
 
 from cli_common.log import get_logger
 from cli_common.taskcluster import get_service
-from cli_common.utils import wait_until
 
 from shipit_code_coverage.secrets import secrets
 
@@ -45,7 +44,7 @@ class Notifier(object):
 
             try:
                 rev = changeset['node']
-                coverage = wait_until(lambda: self.get_coverage_summary(rev), 10)
+                coverage = retry(lambda: self.get_coverage_summary(rev))
                 if coverage is None:
                     continue
 

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -73,4 +73,4 @@ def codecov_wait(commit):
         r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev/commit/{}?access_token={}'.format(commit, secrets[secrets.CODECOV_ACCESS_TOKEN]))
         return True if r.json()['commit']['totals'] is not None else False
 
-    return utils.wait_until(check_codecov_job, 30) is not None
+    return utils.retry(check_codecov_job) is not None


### PR DESCRIPTION
This replaces all occurrences of `utils.wait_until` by `utils.retry` and removes the `utils.wait_until` function. :sparkles: