### PR TITLE
shipit_code_coverage: Log ActiveData errors and increase severity of codecov.io timeouts

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -161,7 +161,7 @@ class CodeCov(object):
                     c.executemany('INSERT INTO chunk_to_test VALUES (?,?,?)', chunk_test_iter)
                 except KeyError:
                     # ActiveData is failing too often, so we need to ignore the error here.
-                    pass
+                    logger.error('Failed to retrieve chunk to tests mapping from ActiveData.')
 
         with tarfile.open('code-coverage-reports/chunk_mapping.tar.xz', 'w:xz') as tar:
             tar.add('chunk_mapping.sqlite')

--- a/src/shipit_code_coverage/shipit_code_coverage/codecov.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/codecov.py
@@ -205,7 +205,7 @@ class CodeCov(object):
                 logger.info('Build ingested by codecov.io')
                 self.notifier.notify()
             else:
-                logger.info('codecov.io took too much time to ingest data.')
+                logger.error('codecov.io took too much time to ingest data.')
         else:
             mkdir('code-coverage-reports')
 


### PR DESCRIPTION
Fixes #949.