### PR TITLE
shipit-static-analysis: Fix mozlint line number format.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -69,7 +69,7 @@ class MozLintIssue(Issue):
         '''
         Build the text content for reporters
         '''
-        linter = self.rule and '{}: {}'.format(self.linter, self.rule) or self.linter
+        linter = '{}: {}'.format(self.linter, self.rule) if self.rule else self.linter
         return '{}: {} [{}]'.format(
             self.level.capitalize(),
             self.message.capitalize(),

--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -32,7 +32,7 @@ class MozLintIssue(Issue):
         self.path = repo_path
         self.column = column
         self.level = level
-        self.line = lineno
+        self.line = int(lineno)  # mozlint sometimes produce strings here
         self.linter = linter
         self.message = message
         self.rule = rule
@@ -69,11 +69,11 @@ class MozLintIssue(Issue):
         '''
         Build the text content for reporters
         '''
-        return '{}: {} [{}: {}]'.format(
+        linter = self.rule and '{}: {}'.format(self.linter, self.rule) or self.linter
+        return '{}: {} [{}]'.format(
             self.level.capitalize(),
             self.message.capitalize(),
-            self.linter,
-            self.rule,
+            linter,
         )
 
     def as_markdown(self):

--- a/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
@@ -178,6 +178,8 @@ class MozReview(object):
 
         TODO: Convert to a faster search algorithm.
         '''
+        assert isinstance(line_num, int), \
+            'Line number must be an integer'
         f = self.destfile_to_file(filename)
         diff_data = self._file_to_diffdata.setdefault(f, f.get_diff_data())
 
@@ -189,6 +191,9 @@ class MozReview(object):
             for row in chunk.lines:
                 if row[line_num_index] == line_num:
                     return row[0]
+
+        # MozReview needs a line number to allow comment publication
+        raise Exception('No translated line number found: {} #{}'.format(filename, line_num))
 
     def comment(self, filename, first_line, num_lines, text,
                 issue_opened=True):


### PR DESCRIPTION
Codespell comments are crashing the mozreview publication (`None` as a line number)