### PR TITLE
shipit-workflow: enable Heroku deployments

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -648,6 +648,7 @@ PROJECTS = {
         'requires': [
             'postgresql',
         ],
+        'deploy': 'HEROKU',
         'deploy_options': {
             'testing': {
                 'heroku_app': 'shipit-testing-workflow',


### PR DESCRIPTION
I also submitted https://github.com/mozilla-releng/build-cloud-tools/pull/332 to add DNS for the staging app.