### PR TITLE
Fix payload for scheduled hooks

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -110,7 +110,7 @@ in rec {
       {
         "$merge" = [
           env
-          { "$eval" = "payload.extra_env"; }
+          { "$eval" = "payload"; }
         ];
       };
 

--- a/src/shipit_pulse_listener/shipit_pulse_listener/hook.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/hook.py
@@ -39,7 +39,7 @@ class Hook(object):
         '''
         assert self.hooks is not None
 
-        task = self.hooks.triggerHook(self.group_id, self.hook_id, {'extra_env': extra_env})
+        task = self.hooks.triggerHook(self.group_id, self.hook_id, extra_env)
         task_id = task['status']['taskId']
         logger.info('Triggered a new task', id=task_id)
 

--- a/src/shipit_pulse_listener/tests/test_hook.py
+++ b/src/shipit_pulse_listener/tests/test_hook.py
@@ -22,7 +22,7 @@ async def test_create_task(HooksMock):
     assert task_id == 'fake_task_id'
     assert HooksMock.obj['group_id'] == 'aGroup'
     assert HooksMock.obj['hook_id'] == 'aHook'
-    assert HooksMock.obj['payload'] == {'extra_env': {}}
+    assert HooksMock.obj['payload'] == {}
 
     assert task_monitoring.tasks.qsize() == 1
     group_id, hook_id, task_id = await task_monitoring.tasks.get()
@@ -41,7 +41,7 @@ async def test_create_task_extra_env(HooksMock):
     assert task_id == 'fake_task_id'
     assert HooksMock.obj['group_id'] == 'aGroup'
     assert HooksMock.obj['hook_id'] == 'aHook'
-    assert HooksMock.obj['payload'] == {'extra_env': {'test': 'succeeded'}}
+    assert HooksMock.obj['payload'] == {'test': 'succeeded'}
 
     assert task_monitoring.tasks.qsize() == 1
     group_id, hook_id, task_id = await task_monitoring.tasks.get()


### PR DESCRIPTION
When a hook is triggered by cron, its payload is `{}`, so there's no `extra_env` property, so the trigger fails because the payload doesn't match the trigger schema.
The simplest fix is to make the extra_env the payload, this way tasks triggered by cron simply have no extra env, and tasks triggered by pulse listener have the extra env as the payload directly (and not as a property of the payload).