### PR TITLE
shipit-workflow: release_eta is optional

### DIFF
--- a/src/shipit_workflow/shipit_workflow/api.py
+++ b/src/shipit_workflow/shipit_workflow/api.py
@@ -52,7 +52,7 @@ def add_release(body):
         branch=body['branch'],
         revision=body['revision'],
         build_number=body['build_number'],
-        release_eta=body['release_eta'],
+        release_eta=body.get('release_eta'),
         status='scheduled',
         partial_updates=body.get('partial_updates')
     )


### PR DESCRIPTION
api.yml doesn't require it, let's do the same in the code!