### PR TITLE
update the workflows

### DIFF
--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -17,10 +17,10 @@ log = get_logger(__name__)
 
 # Phases per product, ordered
 SUPPORTED_FLAVORS = {
-    'firefox': ['promote_firefox', 'promote_firefox_partners', 'push_firefox', 'ship_firefox'],
-    'firefox_rc': ['promote_firefox_rc', 'promote_firefox_partners', 'push_firefox', 'ship_firefox_rc'],
+    'firefox': ['promote_firefox', 'push_firefox', 'ship_firefox'],
+    'firefox_rc': ['promote_firefox_rc', 'ship_firefox_rc', 'push_firefox', 'ship_firefox'],
     'fennec': ['promote_fennec', 'ship_fennec'],
-    'fennec_rc': ['promote_fennec', 'ship_fennec_rc'],
+    'fennec_rc': ['promote_fennec', 'ship_fennec_rc', 'ship_fennec'],
     'devedition': ['promote_devedition', 'push_devedition', 'ship_devedition'],
 }
 


### PR DESCRIPTION
We probably need a firefox off-cycle partner workflow as well, but we haven't fully defined that yet. It'll probably look like ['promote_firefox_partners', 'push_firefox_partners'] or just ['promote_firefox_partners']. That flavor takes a promote action task ID so we don't redo the entire promote graph.