### PR TITLE
please_cli: multiple base docker image changes

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -33,7 +33,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-37"
+      image: "mozillareleng/services:base-dnd-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -72,7 +72,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-37"
+      image: "mozillareleng/services:base-dnd-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -111,7 +111,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-37"
+      image: "mozillareleng/services:base-dnd-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -150,7 +150,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-37"
+      image: "mozillareleng/services:base-dnd-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -189,7 +189,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-37"
+      image: "mozillareleng/services:base-dnd-37"
       features:
         taskclusterProxy: true
       capabilities:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -33,7 +33,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-new-37"
+      image: "mozillareleng/services:base-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -72,7 +72,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-new-37"
+      image: "mozillareleng/services:base-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -111,7 +111,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-new-37"
+      image: "mozillareleng/services:base-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -150,7 +150,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-new-37"
+      image: "mozillareleng/services:base-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -189,7 +189,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-new-37"
+      image: "mozillareleng/services:base-37"
       features:
         taskclusterProxy: true
       capabilities:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -33,7 +33,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-dnd-37"
+      image: "mozillareleng/services:base-new-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -72,7 +72,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-dnd-37"
+      image: "mozillareleng/services:base-new-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -111,7 +111,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-dnd-37"
+      image: "mozillareleng/services:base-new-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -150,7 +150,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-dnd-37"
+      image: "mozillareleng/services:base-new-37"
       features:
         taskclusterProxy: true
       capabilities:
@@ -189,7 +189,7 @@ tasks:
     priority: high
     payload:
       maxRunTime: 1800  # 30min
-      image: "mozillareleng/services:base-dnd-37"
+      image: "mozillareleng/services:base-new-37"
       features:
         taskclusterProxy: true
       capabilities:

--- a/lib/please_cli/please_cli/base_image.py
+++ b/lib/please_cli/please_cli/base_image.py
@@ -141,7 +141,7 @@ def cmd(docker_username,
         with click_spinner.spinner():
             result, output, error = cli_common.command.run(
                 [
-                    'sudo',
+                    # 'sudo',
                     docker,
                     'build',
                     '--no-cache',
@@ -171,7 +171,7 @@ def cmd(docker_username,
             with click_spinner.spinner():
                 result, output, error = cli_common.command.run(
                     [
-                        'sudo',
+                        # 'sudo',
                         docker,
                         'login',
                         '--username', docker_username,
@@ -187,7 +187,7 @@ def cmd(docker_username,
             with click_spinner.spinner():
                 result, output, error = cli_common.command.run(
                     [
-                        'sudo',
+                        # 'sudo',
                         docker,
                         'push',
                         '{}:{}'.format(docker_repo, docker_tag),

--- a/lib/please_cli/please_cli/base_image.py
+++ b/lib/please_cli/please_cli/base_image.py
@@ -171,6 +171,7 @@ def cmd(docker_username,
             with click_spinner.spinner():
                 result, output, error = cli_common.command.run(
                     [
+                        'sudo',
                         docker,
                         'login',
                         '--username', docker_username,
@@ -186,6 +187,7 @@ def cmd(docker_username,
             with click_spinner.spinner():
                 result, output, error = cli_common.command.run(
                     [
+                        'sudo',
                         docker,
                         'push',
                         '{}:{}'.format(docker_repo, docker_tag),

--- a/lib/please_cli/please_cli/base_image.py
+++ b/lib/please_cli/please_cli/base_image.py
@@ -21,7 +21,7 @@ import please_cli.utils
 log = cli_common.log.get_logger(__name__)
 
 
-@cli.command(
+@click.command(
     cls=please_cli.utils.ClickCustomCommand,
     short_help="Build base docker image.",
     epilog="Happy hacking!",
@@ -75,7 +75,7 @@ log = cli_common.log.get_logger(__name__)
     is_flag=True,
     help='Push to docker registry',
     )
-@cli_common.click.taskcluster_options
+@cli_common.cli.taskcluster_options
 def cmd(docker_username,
         docker_password,
         docker,

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -43,7 +43,7 @@ DEPLOY_CHANNELS = ['testing', 'staging', 'production']
 
 DOCKER_REGISTRY = "https://index.docker.io"
 DOCKER_REPO = 'mozillareleng/services'
-DOCKER_BASE_TAG = 'base-' + VERSION
+DOCKER_BASE_TAG = 'base-dnd-' + VERSION
 
 NIX_BIN_DIR = os.environ.get("NIX_BIN_DIR", "")  # must end with /
 OPENSSL_BIN_DIR = os.environ.get("OPENSSL_BIN_DIR", "")  # must end with /

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -43,7 +43,7 @@ DEPLOY_CHANNELS = ['testing', 'staging', 'production']
 
 DOCKER_REGISTRY = "https://index.docker.io"
 DOCKER_REPO = 'mozillareleng/services'
-DOCKER_BASE_TAG = 'base-new-' + VERSION
+DOCKER_BASE_TAG = 'base-' + VERSION
 
 NIX_BIN_DIR = os.environ.get("NIX_BIN_DIR", "")  # must end with /
 OPENSSL_BIN_DIR = os.environ.get("OPENSSL_BIN_DIR", "")  # must end with /

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -377,8 +377,8 @@ def cmd(ctx,
             owner,
             channel,
             taskcluster_secret,
-            secrets.get('CACHE_BUCKET'),
-            secrets.get('CACHE_REGION'),
+            pull_request and None or secrets.get('CACHE_BUCKET'),
+            pull_request and None or secrets.get('CACHE_REGION'),
         )
         tasks.append((project_uuid, build_tasks[project_uuid]))
 

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -377,8 +377,8 @@ def cmd(ctx,
             owner,
             channel,
             taskcluster_secret,
-            pull_request and None or secrets.get('CACHE_BUCKET'),
-            pull_request and None or secrets.get('CACHE_REGION'),
+            pull_request is None and secrets.get('CACHE_BUCKET') or None,
+            pull_request is None and secrets.get('CACHE_REGION') or None,
         )
         tasks.append((project_uuid, build_tasks[project_uuid]))
 

--- a/lib/please_cli/please_cli/utils.py
+++ b/lib/please_cli/please_cli/utils.py
@@ -2,10 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
+import os
+
+import click
 
 import cli_common.log
-import click
+
 
 log = cli_common.log.get_logger(__name__)
 
@@ -95,3 +97,23 @@ class ClickCustomGroup(click.Group, ClickCustomCommand):
         if rows:
             with formatter.section('COMMANDS'):
                 formatter.write_dl(rows)
+
+
+def which(program):
+    """Find executable
+    """
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -106,7 +106,7 @@ USER root
 RUN chown -R root:root /nix \
  && chmod 1777 /nix/var/nix/profiles/per-user /nix/var/nix/gcroots/per-user \
  && rm -f /nix/var/nix/profiles/per-user/app/channels* \
- && mv /nix/var/nix/profiles/per-user/app/profile-1-link /nix/var/nix/profiles/default-1-link \
+ && mv /nix/var/nix/profiles/per-user/app/profile-2-link /nix/var/nix/profiles/default-2-link \
  && cd /nix/var/nix/profiles && ln -s default-1-link default && cd $HOME \
  && /nix/var/nix/profiles/default/bin/nix-env -iA bash -p /nix/var/nix/profiles/sandbox -f /etc/nix/nixpkgs \
  && /nix/var/nix/profiles/default/bin/nix-env -iA cacert -p /nix/var/nix/profiles/default -f /etc/nix/nixpkgs \

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -107,7 +107,7 @@ RUN chown -R root:root /nix \
  && chmod 1777 /nix/var/nix/profiles/per-user /nix/var/nix/gcroots/per-user \
  && rm -f /nix/var/nix/profiles/per-user/app/channels* \
  && mv /nix/var/nix/profiles/per-user/app/profile-2-link /nix/var/nix/profiles/default-2-link \
- && cd /nix/var/nix/profiles && ln -s default-1-link default && cd $HOME \
+ && cd /nix/var/nix/profiles && ln -s default-2-link default && cd $HOME \
  && /nix/var/nix/profiles/default/bin/nix-env -iA bash -p /nix/var/nix/profiles/sandbox -f /etc/nix/nixpkgs \
  && /nix/var/nix/profiles/default/bin/nix-env -iA cacert -p /nix/var/nix/profiles/default -f /etc/nix/nixpkgs \
  && BASH_PATH=$(realpath /nix/var/nix/profiles/sandbox/bin/bash) \

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -94,6 +94,7 @@ RUN wget -nv "https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x
  && . $HOME/.nix-profile/etc/profile.d/nix.sh \
  && rm -r $HOME/nix-*-x86_64-linux \
  && rm -rf $HOME/.cache/nix \
+ && nix-env -iA nixpkgs.docker \
  && nix-build /app/nix/default.nix -A please-cli -o result \
  && nix-collect-garbage -d \
  && rm -f result

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -114,8 +114,8 @@ RUN chown -R root:root /nix \
  && BASH_DEPS=$(sudo "/nix/var/nix/profiles/default/bin/nix-store" -qR "$BASH_PATH" | tr '\n' ' ') \
  && echo "sandbox = true" >> /etc/nix/nix.conf \
  && echo "sandbox-paths = /bin/sh=$BASH_PATH $BASH_DEPS">> /etc/nix/nix.conf \
- && nix-collect-garbage -d \
- && nix optimise-store
+ && /nix/var/nix/profiles/default/bin/nix-collect-garbage -d \
+ && /nix/var/nix/profiles/default/bin/nix optimise-store
 
 
 COPY nix/docker/profile.sh /etc/nix/

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -92,12 +92,12 @@ RUN wget -nv "https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x
  && tar jxf "nix-$NIX_VERSION-x86_64-linux.tar.bz2" \
  && sh ./nix-$NIX_VERSION-x86_64-linux/install \
  && . $HOME/.nix-profile/etc/profile.d/nix.sh \
+ #&& nix-env -iA nixpkgs.docker nixpkgs.neovim nixpkgs.git \
+ && nix-build /app/nix/default.nix -A please-cli -o /home/app/result-please-cli \
  && rm -r $HOME/nix-*-x86_64-linux \
  && rm -rf $HOME/.cache/nix \
- && nix-env -iA nixpkgs.docker nixpkgs.neovim nixpkgs.git \
- && nix-build /app/nix/default.nix -A please-cli -o result \
  && nix-collect-garbage -d \
- && rm -f result
+ && nix optimise-store
 
 
 USER root
@@ -113,7 +113,10 @@ RUN chown -R root:root /nix \
  && BASH_PATH=$(realpath /nix/var/nix/profiles/sandbox/bin/bash) \
  && BASH_DEPS=$(sudo "/nix/var/nix/profiles/default/bin/nix-store" -qR "$BASH_PATH" | tr '\n' ' ') \
  && echo "sandbox = true" >> /etc/nix/nix.conf \
- && echo "sandbox-paths = /bin/sh=$BASH_PATH $BASH_DEPS">> /etc/nix/nix.conf
+ && echo "sandbox-paths = /bin/sh=$BASH_PATH $BASH_DEPS">> /etc/nix/nix.conf \
+ && nix-collect-garbage -d \
+ && nix optimise-store
+
 
 COPY nix/docker/profile.sh /etc/nix/
 

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -106,8 +106,8 @@ USER root
 RUN chown -R root:root /nix \
  && chmod 1777 /nix/var/nix/profiles/per-user /nix/var/nix/gcroots/per-user \
  && rm -f /nix/var/nix/profiles/per-user/app/channels* \
- && mv /nix/var/nix/profiles/per-user/app/profile-2-link /nix/var/nix/profiles/default-2-link \
- && cd /nix/var/nix/profiles && ln -s default-2-link default && cd $HOME \
+ && mv /nix/var/nix/profiles/per-user/app/profile-1-link /nix/var/nix/profiles/default-1-link \
+ && cd /nix/var/nix/profiles && ln -s default-1-link default && cd $HOME \
  && /nix/var/nix/profiles/default/bin/nix-env -iA bash -p /nix/var/nix/profiles/sandbox -f /etc/nix/nixpkgs \
  && /nix/var/nix/profiles/default/bin/nix-env -iA cacert -p /nix/var/nix/profiles/default -f /etc/nix/nixpkgs \
  && BASH_PATH=$(realpath /nix/var/nix/profiles/sandbox/bin/bash) \

--- a/nix/docker/Dockerfile
+++ b/nix/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN wget -nv "https://nixos.org/releases/nix/nix-$NIX_VERSION/nix-$NIX_VERSION-x
  && . $HOME/.nix-profile/etc/profile.d/nix.sh \
  && rm -r $HOME/nix-*-x86_64-linux \
  && rm -rf $HOME/.cache/nix \
- && nix-env -iA nixpkgs.docker \
+ && nix-env -iA nixpkgs.docker nixpkgs.neovim nixpkgs.git \
  && nix-build /app/nix/default.nix -A please-cli -o result \
  && nix-collect-garbage -d \
  && rm -f result

--- a/please
+++ b/please
@@ -71,7 +71,7 @@ else
             --workdir=/app \
             -p 7000:7000 \
             -p 8000-8100:8000-8100 \
-            mozillareleng/services:base-`cat ./VERSION`
+            mozillareleng/services:base-dnd-`cat ./VERSION`
       else
         docker start $DOCKER_NAME
       fi

--- a/please
+++ b/please
@@ -49,7 +49,6 @@ if [ "$USE_NIX" = "1" ]; then
   nix_store_file=`cat $drv | cut -c17-91`
   if [ ! -e $nix_store_file ]; then
     echo -n "Building please command (this might take a minute or two the first time) ... ";
-    echo "${GREEN}DONE${NC}";
   fi
   silent nix-build nix/default.nix -A please-cli -o result-please-cli;
   if [ ! -e $nix_store_file ]; then

--- a/please
+++ b/please
@@ -14,7 +14,7 @@ NC='\033[0m'
 
 
 USE_DOCKER=1
-USE_NIX=1
+USE_NIX=0
 if [ -f /.dockerenv ]; then
   USE_NIX=1
   . /etc/nix/profile.sh;
@@ -47,7 +47,7 @@ else
             --workdir=/app \
             -p 7000:7000 \
             -p 8000-8100:8000-8100 \
-            mozillareleng/services:base-`cat ./VERSION`
+            mozillareleng/services:base-dnd-`cat ./VERSION`
       else
         docker start $DOCKER_NAME
       fi

--- a/please
+++ b/please
@@ -14,7 +14,7 @@ NC='\033[0m'
 
 
 USE_DOCKER=1
-USE_NIX=0
+USE_NIX=1
 if [ -f /.dockerenv ]; then
   USE_NIX=1
   . /etc/nix/profile.sh;
@@ -47,7 +47,7 @@ else
             --workdir=/app \
             -p 7000:7000 \
             -p 8000-8100:8000-8100 \
-            mozillareleng/services:base-dnd-`cat ./VERSION`
+            mozillareleng/services:base-`cat ./VERSION`
       else
         docker start $DOCKER_NAME
       fi

--- a/please
+++ b/please
@@ -12,32 +12,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-USE_NIX=0
-USE_DOCKER=0
-
-case "`uname`" in
-  Darwin)
-    if hash docker 2>/dev/null; then
-       USE_DOCKER=1
-    fi
-    ;;
-  Linux)
-    if hash nix-build 2>/dev/null; then
-         USE_NIX=1
-    else
-      if hash docker 2>/dev/null; then
-         USE_DOCKER=1
-      fi
-    fi
-    ;;
-  *)
-    echo "ERROR: Unknown platform '$OSTYPE'"
-    exit 1
-    ;;
-esac
 
 USE_DOCKER=1
-
 USE_NIX=0
 if [ -f /.dockerenv ]; then
   USE_NIX=1

--- a/please
+++ b/please
@@ -72,7 +72,7 @@ else
             --workdir=/app \
             -p 7000:7000 \
             -p 8000-8100:8000-8100 \
-            mozillareleng/services:base-dnd-`cat ./VERSION`
+            mozillareleng/services:base-`cat ./VERSION`
       else
         docker start $DOCKER_NAME
       fi

--- a/please
+++ b/please
@@ -14,8 +14,6 @@ NC='\033[0m'
 
 USE_NIX=0
 USE_DOCKER=0
-# TODO: in addition to version we should also use hash of nix/docker folder
-DOCKER_NAME="mozilla-releng-services-v`cat ./VERSION`"
 
 case "`uname`" in
   Darwin)
@@ -61,9 +59,20 @@ if [ "$USE_NIX" = "1" ]; then
 
 else
   if [ "$USE_DOCKER" = "1" ]; then
+    DOCKER_HASH="`pwd``git rev-parse --abbrev-ref HEAD`"
+    DOCKER_NAME="mozilla-releng-services-v`cat ./VERSION`-`echo -n $DOCKER_HASH | sha256sum | cut -d ' ' -f 1`"
     if [ ! "$(docker ps -q -f name=$DOCKER_NAME)" ]; then
       if [ ! "$(docker ps -qa -f name=$DOCKER_NAME)" ]; then
-        docker run --privileged -td --name $DOCKER_NAME --volume="$(pwd)":/app --workdir=/app -p 7000:7000 -p 8000-8100:8000-8100 mozillareleng/services:base-`cat ./VERSION`
+        docker run \
+            --privileged \
+            -td \
+            --name $DOCKER_NAME \
+            --volume="$(pwd)":/app \
+            --volume=/var/run/docker.sock:/var/run/docker.sock \
+            --workdir=/app \
+            -p 7000:7000 \
+            -p 8000-8100:8000-8100 \
+            mozillareleng/services:base-dnd-`cat ./VERSION`
       else
         docker start $DOCKER_NAME
       fi

--- a/src/releng_docs/deploy/weekly-releases.rst
+++ b/src/releng_docs/deploy/weekly-releases.rst
@@ -106,10 +106,8 @@ Protocal that we follow is:
    .. code-block:: console
 
         $ ./please -vv tools base-image \
-            --docker-repo="mozillareleng/services" \
-            --docker-tag="base-$(cat ./VERSION)" \
-            --docker-username="..." \
-            --docker-password="..."
+            --taskcluster-client-id="..." \
+            --taskcluster-access-token="..."
 
    Docker username and password you get in `staging secrets`_ or `production
    secrets`_ secrets.


### PR DESCRIPTION
* make it possible to build docker image again. this was broken since we switched development environment to docker. now it is possible to build docker image from docker container. this will also allow us in the near future to build base docker images on each commit.

* With move to nix sandbox and docker base-image command was broken.
  this commit included a fix for this since it installs docker inside
  base image and forwards docker socket. fixes #1003

* Stores credentials and other secrets in taskcluster secrets service.
  That makes the command easier to use.

* weekly release documentation has been updated how to use new command

* docker container will now has a hash at the end of the name calculated
  from current directory and branch. That means we can use multiple
  containers across multiple branches/worktrees.

* add git and neovim to base image

* adding --dont-push flag to base-image command to not push generated docker image to docker registry 

* we were still accidentally pushing to S3 on pull requests 