### PR TITLE
shipit_code_coverage: Raise exception when the artifact status code is not 200

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -83,6 +83,8 @@ def download_artifact(artifact_path, task_id, artifact_name):
     def perform_download():
         r = requests.get(queue_base + 'task/{}/artifacts/{}'.format(task_id, artifact_name), stream=True)
 
+        r.raise_for_status()
+
         with open(artifact_path, 'wb') as f:
             r.raw.decode_content = True
             shutil.copyfileobj(r.raw, f)


### PR DESCRIPTION
Before this PR, we were downloading errored artifacts anyway and then failing with BadZipFile. With this PR, we are more precise with the error messages.

Here's an example invalid artifact: https://taskcluster-artifacts.net/FBdocjnAQOW_GJDOfmgjxw/0/public/test_info/code-coverage-grcov.zip.