### PR TITLE
shipit-static-analysis: Support generic analyzers

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/__init__.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/__init__.py
@@ -41,6 +41,12 @@ class Issue(object):
         '''
         raise NotImplementedError
 
+    def as_diff(self):
+        '''
+        Build the ED compatible diff to build an improvement patch
+        '''
+        raise NotImplementedError
+
     def is_third_party(self):
         '''
         Is this issue in a third party path ?

--- a/src/shipit_static_analysis/shipit_static_analysis/__init__.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/__init__.py
@@ -6,13 +6,14 @@
 from shipit_static_analysis.config import settings
 from shipit_static_analysis.stats import Datadog
 import os
+import abc
 
 CLANG_TIDY = 'clang-tidy'
 CLANG_FORMAT = 'clang-format'
 MOZLINT = 'mozlint'
 
 
-class Issue(object):
+class Issue(abc.ABC):
     '''
     Common reported issue interface
 
@@ -22,6 +23,7 @@ class Issue(object):
     - line: Line where the issue begins
     - nb_lines: Number of lines affected by the issue
     '''
+    @abc.abstractmethod
     def is_publishable(self):
         '''
         Is this issue publishable on reporters ?
@@ -29,18 +31,21 @@ class Issue(object):
         '''
         raise NotImplementedError
 
+    @abc.abstractmethod
     def as_text(self):
         '''
         Build the text content for reporters
         '''
         raise NotImplementedError
 
+    @abc.abstractmethod
     def as_markdown(self):
         '''
         Build the Markdown content for debug email
         '''
         raise NotImplementedError
 
+    @abc.abstractmethod
     def as_diff(self):
         '''
         Build the ED compatible diff to build an improvement patch

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/format.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/format.py
@@ -6,8 +6,8 @@ import subprocess
 from cli_common.log import get_logger
 from shipit_static_analysis import Issue
 from shipit_static_analysis import stats
-from shipit_static_analysis.revisions import Revision
 from shipit_static_analysis.config import settings
+from shipit_static_analysis.revisions import Revision
 
 logger = get_logger(__name__)
 

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -61,11 +61,10 @@ class ClangTidy(object):
     Clang Tidy Parallel runner
     Inspired by run-clang-tidy.py
     '''
-    def __init__(self, repo_dir, build_dir, validate_checks=True):
+    def __init__(self, repo_dir, validate_checks=True):
         assert os.path.isdir(repo_dir)
 
         self.repo_dir = repo_dir
-        self.build_dir = os.path.join(repo_dir, build_dir)
         self.binary = os.path.join(
             os.environ['MOZBUILD_STATE_PATH'],
             'clang-tools', 'clang', 'bin', 'clang-tidy',
@@ -79,7 +78,7 @@ class ClangTidy(object):
                 logger.error('Specified clang-tidy check "{}" not found.'.format(missing))
 
     @stats.api.timed('runtime.clang-tidy')
-    def run(self, checks, revision):
+    def run(self, revision):
         '''
         Run modified files with specified checks through clang-tidy
         using threaded workers (communicate through queues)
@@ -100,7 +99,7 @@ class ClangTidy(object):
                 for filename in revision.files
             )),
 
-            '--checks={}'.format(','.join(c['name'] for c in checks)),
+            '--checks={}'.format(','.join(c['name'] for c in settings.clang_checkers)),
         ] + list(revision.files)
         logger.info('Running static-analysis', cmd=' '.join(cmd))
 

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -286,3 +286,8 @@ class ClangTidyIssue(Issue):
                 ) for n in self.notes
             ]),
         )
+
+    def as_diff():
+        '''
+        No diff available
+        '''

--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -93,6 +93,11 @@ class MozLintIssue(Issue):
             disabled_rule=self.is_disabled_rule() and 'yes' or 'no',
         )
 
+    def as_diff():
+        '''
+        No diff available
+        '''
+
 
 class MozLint(object):
     '''

--- a/src/shipit_static_analysis/shipit_static_analysis/report/mail.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/mail.py
@@ -41,7 +41,7 @@ class MailReporter(Reporter):
 
         logger.info('Mail report enabled', emails=self.emails)
 
-    def publish(self, issues, revision, diff_url=None):
+    def publish(self, issues, revision):
         '''
         Send an email to administrators
         '''
@@ -62,7 +62,7 @@ class MailReporter(Reporter):
             publishable=sum([i.is_publishable() for i in issues]),
             stats=stats,
             review_url=revision.url,
-            diff_url=diff_url or 'no clang-format diff',
+            diff_url=revision.diff_url or 'no improvement diff',
         )
         content += '\n\n'.join([i.as_markdown() for i in issues])
         if len(content) > 102400:

--- a/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
@@ -60,7 +60,7 @@ class MozReviewReporter(Reporter):
 
         logger.info('Mozreview report enabled', url=url, username=username, analyzers=self.analyzers)
 
-    def publish(self, issues, revision, diff_url=None):  # noqa
+    def publish(self, issues, revision):
         '''
         Publish comments on mozreview
         '''
@@ -92,7 +92,7 @@ class MozReviewReporter(Reporter):
             # Build complex top comment
             comment = self.build_comment(
                 issues=issues,
-                diff_url=diff_url,
+                diff_url=revision.diff_url,
                 max_comments=MAX_COMMENTS
             )
 

--- a/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
@@ -85,7 +85,7 @@ class PhabricatorReporter(Reporter):
             diffID=diff_id,
         )
 
-    def publish(self, issues, revision, diff_url=None):
+    def publish(self, issues, revision):
         '''
         Publish inline comments for each issues
         '''
@@ -116,7 +116,7 @@ class PhabricatorReporter(Reporter):
                 revision,
                 self.build_comment(
                     issues=issues,
-                    diff_url=diff_url,
+                    diff_url=revision.diff_url,
                 ),
             )
             stats.api.increment('report.phabricator.issues', len(inlines))

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -25,6 +25,7 @@ class Revision(object):
     files = []
     lines = {}
     patch = None
+    diff_path = None
     diff_url = None
 
     def analyze_patch(self):

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -25,6 +25,7 @@ class Revision(object):
     files = []
     lines = {}
     patch = None
+    diff_url = None
 
     def analyze_patch(self):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -25,7 +25,6 @@ class Revision(object):
     files = []
     lines = {}
     patch = None
-    diff_path = None
     diff_url = None
 
     def analyze_patch(self):

--- a/src/shipit_static_analysis/shipit_static_analysis/utils.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import os
+import tempfile
+from contextlib import contextmanager
+
+
+@contextmanager
+def build_temp_file(content, suffix):
+    '''
+    Build a temporary file and remove it after usage
+    '''
+    assert isinstance(content, str)
+    assert isinstance(suffix, str)
+
+    # Write patch in tmp
+    _, path = tempfile.mkstemp(suffix=suffix)
+    with open(path, 'w') as f:
+        f.write(content)
+
+    yield path
+
+    # Cleanup
+    os.unlink(path)

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -3,10 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-import tempfile
-import subprocess
 import itertools
+import os
+import subprocess
+import tempfile
+
 import hglib
 
 from cli_common.command import run_check

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -367,3 +367,22 @@ def mock_clang(tmpdir, monkeypatch):
         return real_check_output(command, *args, **kwargs)
 
     monkeypatch.setattr(subprocess, 'check_output', mock_mach)
+
+
+@pytest.fixture
+def mock_workflow(tmpdir, mock_repository):
+    '''
+    Mock the full workflow, without cloning
+    '''
+    from shipit_static_analysis.workflow import Workflow
+
+    class MockWorkflow(Workflow):
+        def clone(self):
+            self.repo_dir = str(mock_repository.directory.realpath())
+            return hglib.open(self.repo_dir)
+
+    return MockWorkflow(
+        cache_root=str(tmpdir.realpath()),
+        reporters=[],
+        analyzers=['clang-tidy', 'clang-format', 'mozlint'],
+    )

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -381,6 +381,10 @@ def mock_workflow(tmpdir, mock_repository):
             self.repo_dir = str(mock_repository.directory.realpath())
             return hglib.open(self.repo_dir)
 
+    # Needed for Taskcluster build
+    if 'MOZCONFIG' not in os.environ:
+        os.environ['MOZCONFIG'] = str(tmpdir.join('mozconfig').realpath())
+
     return MockWorkflow(
         cache_root=str(tmpdir.realpath()),
         reporters=[],

--- a/src/shipit_static_analysis/tests/mocks/config.yaml
+++ b/src/shipit_static_analysis/tests/mocks/config.yaml
@@ -5,5 +5,7 @@ clang_checkers:
    publish: !!bool yes
  - name: clang-analyzer-security.*
    publish: !!bool no
+ - name: modernize-use-nullptr
+   publish: !!bool yes
 
 third_party: 3rdparty.txt

--- a/src/shipit_static_analysis/tests/test_clang.py
+++ b/src/shipit_static_analysis/tests/test_clang.py
@@ -62,7 +62,7 @@ def test_expanded_macros(mock_stats):
     assert issue.is_expanded_macro() is False
 
 
-def test_clang_format(mock_repository, mock_stats, mock_clang, mock_revision):
+def test_clang_format(mock_repository, mock_stats, mock_clang, mock_revision, mock_workflow):
     '''
     Test clang-format runner
     '''
@@ -93,6 +93,7 @@ def test_clang_format(mock_repository, mock_stats, mock_clang, mock_revision):
     assert issue.as_diff() == BAD_CPP_DIFF
 
     # At the end of the process, original file is patched
+    mock_workflow.build_improvement_patch(mock_revision, issues)
     assert bad_file.read() == BAD_CPP_VALID
 
     # Test stats

--- a/src/shipit_static_analysis/tests/test_clang.py
+++ b/src/shipit_static_analysis/tests/test_clang.py
@@ -78,10 +78,9 @@ def test_clang_format(mock_repository, mock_stats, mock_clang, mock_revision):
     mock_revision.lines = {
         'bad.cpp': [1, 2, 3],
     }
-    issues, patched = cf.run(frozenset(['.cpp', ]), mock_revision)
+    issues = cf.run(mock_revision)
 
     # Small file, only one issue which group changes
-    assert patched == ['bad.cpp', ]
     assert isinstance(issues, list)
     assert len(issues) == 1
     issue = issues[0]
@@ -138,11 +137,7 @@ def test_clang_tidy(mock_repository, mock_config, mock_clang, mock_stats, mock_r
     mock_revision.lines = {
         'bad.cpp': range(len(BAD_CPP_TIDY.split('\n'))),
     }
-    checks = [{
-        'name': 'modernize-use-nullptr',
-        'publish': True,
-    }]
-    issues = ct.run(checks, mock_revision)
+    issues = ct.run(mock_revision)
     assert len(issues) == 2
     assert isinstance(issues[0], ClangTidyIssue)
     assert issues[0].check == 'modernize-use-nullptr'
@@ -159,7 +154,7 @@ def test_clang_tidy(mock_repository, mock_config, mock_clang, mock_stats, mock_r
 
     metrics = mock_stats.get_metrics('issues.clang-tidy.publishable')
     assert len(metrics) == 1
-    assert metrics[0][1] == 0
+    assert metrics[0][1] == 2
 
     metrics = mock_stats.get_metrics('runtime.clang-tidy.avg')
     assert len(metrics) == 1
@@ -175,10 +170,8 @@ def test_clang_tidy_checks(mock_repository, mock_clang):
 
     # Get the set of all available checks that the local clang-tidy offers
     repo_dir = mock_repository.directory
-    build_dir = repo_dir.mkdir('../build')
     clang_tidy = ClangTidy(
         str(repo_dir.realpath()),
-        str(build_dir.realpath()),
         validate_checks=False,
     )
 

--- a/src/shipit_static_analysis/tests/test_reporter_mail.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mail.py
@@ -91,10 +91,10 @@ def test_mail(mock_issues, mock_phabricator):
 
     # Publish for mozreview
     mrev = MozReviewRevision('abcdef:12345:1')
-    r.publish(mock_issues, mrev, diff_url=None)
+    r.publish(mock_issues, mrev)
 
     prev = PhabricatorRevision('42:PHID-DIFF-test', phab)
-    r.publish(mock_issues, prev, diff_url=None)
+    r.publish(mock_issues, prev)
 
     # Check stats
     mock_cls = mock_issues[0].__class__

--- a/src/shipit_static_analysis/tests/test_reporter_mozreview.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mozreview.py
@@ -41,7 +41,7 @@ def test_review_publication(mock_mozreview, mock_issues, mock_phabricator):
     }
     r = MozReviewReporter(conf, 'test_tc', 'token_tc')
     mrev = MozReviewRevision('abcdef:12345:1')
-    out = r.publish(mock_issues, mrev, diff_url=None)
+    out = r.publish(mock_issues, mrev)
     assert out is None  # no publication (no clang-tidy)
 
 


### PR DESCRIPTION
The decision tree to use **clang-*** analyzers became a bit more complex (available from config + C/C++ files detection + `mach ` setup), so it makes sense to have a more generic setup.

This PR is basically a backport from the first part of #861 (to be reworked & merged this week). Merging first the generic analyzer + generic patch building would simplify a lot the rework of #861.