### PR TITLE
shipit-static-analysis: Download clang build directly from Taskcluster index

### DIFF
--- a/src/shipit_static_analysis/default.nix
+++ b/src/shipit_static_analysis/default.nix
@@ -4,7 +4,7 @@
 let
 
   inherit (releng_pkgs.lib) mkTaskclusterHook mkTaskclusterMergeEnv mkPython fromRequirementsFile filterSource ;
-  inherit (releng_pkgs.pkgs) writeScript gcc cacert gcc-unwrapped glibc glibcLocales xorg patch nodejs git python27 python35 coreutils shellcheck clang_5;
+  inherit (releng_pkgs.pkgs) writeScript gcc cacert gcc-unwrapped glibc glibcLocales xorg patch nodejs git python27 python35 coreutils shellcheck clang_5 zlib;
   inherit (releng_pkgs.pkgs.lib) fileContents concatStringsSep ;
   inherit (releng_pkgs.tools) pypi2nix mercurial;
 
@@ -104,6 +104,7 @@ let
       mkdir -p $out/tmp
       mkdir -p $out/bin
       mkdir -p $out/usr/bin
+      mkdir -p $out/lib64
       ln -s ${mercurial}/bin/hg $out/bin
       ln -s ${patch}/bin/patch $out/bin
 
@@ -119,6 +120,10 @@ let
       ln -s ${coreutils}/bin/env $out/usr/bin/env
       ln -s ${coreutils}/bin/ld $out/bin
       ln -s ${coreutils}/bin/as $out/bin
+
+      # Add program interpreter needed to run clang Taskcluster static build
+      # Found this info by using "readelf -l"
+      ln -s ${glibc}/lib/ld-linux-x86-64.so.2 $out/lib64
 
       # Expose gecko env in final output
       ln -s ${gecko-env}/bin/gecko-env $out/bin
@@ -150,8 +155,13 @@ let
         "MOZCONFIG=${gecko-env}/conf/mozconfig"
         "CODESPELL=${python.packages.codespell}/bin/codespell"
         "SHELLCHECK=${shellcheck}/bin/shellcheck"
+        "MOZ_AUTOMATION=1"
         "MOZBUILD_STATE_PATH=/tmp/mozilla-state"
         "SHELL=xterm"
+
+        # Needed to run clang Taskcluster static build
+        # only on built docker image from scratch
+        "LD_LIBRARY_PATH=${zlib}/lib"
       ];
     dockerCmd = [];
 

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/__init__.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/__init__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import tarfile
+import requests
+import io
+import os
+import cli_common.utils
+
+
+def setup(product='static-analysis', job_name='linux64-clang-tidy', revision='latest', artifact='public/build/clang-tidy.tar.xz'):
+    '''
+    Setup Taskcluster clang build for static-analysis
+    Defaults values are from https://dxr.mozilla.org/mozilla-central/source/taskcluster/ci/toolchain/linux.yml
+    - Download the artifact from latest Taskcluster build
+    - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
+    '''
+    namespace = 'gecko.v2.mozilla-central.{}.{}.{}'.format(revision, product, job_name)
+    artifact_url = 'https://index.taskcluster.net/v1/task/{}/artifacts/{}'.format(namespace, artifact)
+
+    # Mach expects clang binaries in this specific root dir
+    target = os.path.join(
+        os.environ['MOZBUILD_STATE_PATH'],
+        'clang-tools',
+    )
+
+    def _download():
+        # Download Taskcluster archive
+        resp = requests.get(artifact_url, stream=True)
+        resp.raise_for_status()
+
+        # Extract archive into destination
+        tar = tarfile.open(fileobj=io.BytesIO(resp.content))
+        tar.extractall(target)
+        tar.close()
+
+    # Retry several times the download process
+    cli_common.utils.retry(_download)

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/__init__.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/__init__.py
@@ -32,9 +32,8 @@ def setup(product='static-analysis', job_name='linux64-clang-tidy', revision='la
         resp.raise_for_status()
 
         # Extract archive into destination
-        tar = tarfile.open(fileobj=io.BytesIO(resp.content))
-        tar.extractall(target)
-        tar.close()
+        with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
+            tar.extractall(target)
 
     # Retry several times the download process
     cli_common.utils.retry(_download)

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -287,7 +287,7 @@ class ClangTidyIssue(Issue):
             ]),
         )
 
-    def as_diff():
+    def as_diff(self):
         '''
         No diff available
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -93,7 +93,7 @@ class MozLintIssue(Issue):
             disabled_rule=self.is_disabled_rule() and 'yes' or 'no',
         )
 
-    def as_diff():
+    def as_diff(self):
         '''
         No diff available
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -211,7 +211,7 @@ class Workflow(object):
                 'Modified file not found {}'.format(full_path)
 
             # Build raw "ed" patch
-            patch = '\n'.join(issue.as_diff() for issue in file_issues)
+            patch = '\n'.join(filter(None, [issue.as_diff() for issue in file_issues]))
             if not patch:
                 continue
 


### PR DESCRIPTION
Mach does not allow to use `./mach artifact toolchain --from-build` in a Taskcluster environment.