### PR TITLE
please_cli: multiple deployments per project

### DIFF
--- a/lib/cli_common/cli_common/log.py
+++ b/lib/cli_common/cli_common/log.py
@@ -11,6 +11,7 @@ import structlog.exceptions
 
 CHANNELS = [
     'master',
+    'testing',
     'staging',
     'production',
 ]

--- a/lib/please_cli/please_cli/build.py
+++ b/lib/please_cli/please_cli/build.py
@@ -113,27 +113,36 @@ def cmd(project,
                 temp_file,
             ]
 
+        nix_path_attributes = []
         if channel:
-            projects = [(project + '.deploy.' + channel, channel)]
-        else:
-            projects = [(project, None)]
-            project_deploys = please_cli.config.PROJECTS_CONFIG.get(project, dict()).get('deploys', [])
-            for deploy in project_deploys:
-                for channel_ in deploy.get('options', dict()).keys():
-                    if channel_ in please_cli.config.DEPLOY_CHANNELS:
-                        projects.append((project + '.deploy.' + channel_, channel_))
+            deploys = please_cli.config.PROJECTS_CONFIG.get(project, dict()).get('deploys', [])
+            for deploy in deploys:
+                nix_path_attribute = deploy.get('options', dict()).get(channel, dict()).get('nix_path_attribute')
+                if nix_path_attribute:
+                    nix_path_attributes.append(project + '.' + nix_path_attribute)
+                else:
+                    nix_path_attributes.append(project)
 
-        for (attribute, channel_) in projects:
-            channel_attribute = ''
-            if channel_:
-                channel_attribute = '-channel-' + channel_
+        else:
+            deploys = please_cli.config.PROJECTS_CONFIG.get(project, dict()).get('deploys', [])
+            for deploy in deploys:
+                for _channel, options in deploy.get('options', dict()).items():
+                    if _channel in please_cli.config.DEPLOY_CHANNELS:
+                        nix_path_attribute = options.get('nix_path_attribute')
+                        if nix_path_attribute:
+                            nix_path_attributes.append(project + '.' + nix_path_attribute)
+                        else:
+                            nix_path_attributes.append(project)
+
+        nix_path_attributes = list(set(nix_path_attributes))
+
+        for nix_path_attribute in nix_path_attributes:
             command = [
                 nix_build,
                 please_cli.config.ROOT_DIR + '/nix/default.nix',
-                '-A', attribute,
-                '-o', please_cli.config.TMP_DIR + '/result-build-{project}{channel}'.format(
-                    project=project,
-                    channel=channel_attribute,
+                '-A', nix_path_attribute,
+                '-o', please_cli.config.TMP_DIR + '/result-build-{}'.format(
+                    nix_path_attribute.replace('.', '-').replace('_', '-'),
                 ),
             ] + nix_cache_secret_keys
             result, output, error = cli_common.command.run(

--- a/lib/please_cli/please_cli/build.py
+++ b/lib/please_cli/please_cli/build.py
@@ -113,10 +113,15 @@ def cmd(project,
                 temp_file,
             ]
 
-        projects = [(project, None)] + \
-                   [(project + '.deploy.' + x, x) for x in please_cli.config.DEPLOY_CHANNELS]
         if channel:
             projects = [(project + '.deploy.' + channel, channel)]
+        else:
+            projects = [(project, None)]
+            project_deploys = please_cli.config.PROJECTS_CONFIG.get(project, dict()).get('deploys', [])
+            for deploy in project_deploys:
+                for channel_ in deploy.get('options', dict()).keys():
+                    if channel_ in please_cli.config.DEPLOY_CHANNELS:
+                        projects.append((project + '.deploy.' + channel_, channel_))
 
         for (attribute, channel_) in projects:
             channel_attribute = ''

--- a/lib/please_cli/please_cli/check_cache.py
+++ b/lib/please_cli/please_cli/check_cache.py
@@ -60,7 +60,15 @@ def cmd(project, cache_urls, nix_instantiate, channel, indent=0, interactive=Tru
     indent = ' ' * indent
     channel_derivations = dict()
 
-    for tmp_channel in ['master'] + please_cli.config.DEPLOY_CHANNELS:
+    channels = ['master']
+
+    project_deploys = please_cli.config.PROJECTS_CONFIG.get(project, dict()).get('deploys', [])
+    for deploy in project_deploys:
+        for channel_ in deploy.get('options', dict()).keys():
+            if channel_ in please_cli.config.DEPLOY_CHANNELS:
+                channels.append(channel_)
+
+    for tmp_channel in channels:
         project_exists = False
         attribute = project
         if tmp_channel != 'master':

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -58,10 +58,12 @@ TEMPLATES = {
     'backend-json-api': {}
 }
 
+DEV_PROJECTS = ['postgresql']
 PROJECTS = list(map(lambda x: x.replace('_', '-'),
                     filter(lambda x: os.path.exists(os.path.join(SRC_DIR, x, 'default.nix')),
                            os.listdir(SRC_DIR))))
-PROJECTS += ['postgresql']
+PROJECTS += DEV_PROJECTS
+
 
 # TODO: below data should be placed in src/<app>/default.nix files alongside
 PROJECTS_CONFIG = {

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -84,27 +84,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-notif-policy',
-                'heroku_dyno_type': 'web',
-                'url': 'https://policy.notification.testing.mozilla-releng.net',
-                'dns': 'policy.notification.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-notif-policy',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://policy.notification.testing.mozilla-releng.net',
+                        'dns': 'policy.notification.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-notif-policy',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://policy.notification.staging.mozilla-releng.net',
+                        'dns': 'policy.notification.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    'production': {
+                        'heroku_app': 'releng-production-notif-policy',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://policy.notification.mozilla-releng.net',
+                        'dns': 'policy.notification.mozilla-releng.net.herokudns.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-notif-policy',
-                'heroku_dyno_type': 'web',
-                'url': 'https://policy.notification.staging.mozilla-releng.net',
-                'dns': 'policy.notification.staging.mozilla-releng.net.herokudns.com',
-            },
-            'production': {
-                'heroku_app': 'releng-production-notif-policy',
-                'heroku_dyno_type': 'web',
-                'url': 'https://policy.notification.mozilla-releng.net',
-                'dns': 'policy.notification.mozilla-releng.net.herokudns.com',
-            },
-        },
+        ],
     },
     'releng-notification-identity': {
         'checks': [
@@ -118,27 +122,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-notif-identity',
-                'heroku_dyno_type': 'web',
-                'url': 'https://identity.notification.testing.mozilla-releng.net',
-                'dns': 'identity.notification.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-notif-identity',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://identity.notification.testing.mozilla-releng.net',
+                        'dns': 'identity.notification.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-notif-identity',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://identity.notification.staging.mozilla-releng.net',
+                        'dns': 'identity.notification.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    'production': {
+                        'heroku_app': 'releng-production-notif-ident',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://identity.notification.mozilla-releng.net',
+                        'dns': 'identity.notification.mozilla-releng.net.herokudns.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-notif-identity',
-                'heroku_dyno_type': 'web',
-                'url': 'https://identity.notification.staging.mozilla-releng.net',
-                'dns': 'identity.notification.staging.mozilla-releng.net.herokudns.com',
-            },
-            'production': {
-                'heroku_app': 'releng-production-notif-ident',
-                'heroku_dyno_type': 'web',
-                'url': 'https://identity.notification.mozilla-releng.net',
-                'dns': 'identity.notification.mozilla-releng.net.herokudns.com',
-            },
-        },
+        ],
     },
     'releng-archiver': {
         'checks': [
@@ -152,30 +160,34 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-archiver',
-                'heroku_dyno_type': 'web',
-                'url': 'https://archiver.testing.mozilla-releng.net',
-                # TODO: switch to SSL Endpoint
-                'dns': 'archiver.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-archiver',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://archiver.testing.mozilla-releng.net',
+                        # TODO: switch to SSL Endpoint
+                        'dns': 'archiver.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-archiver',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://archiver.staging.mozilla-releng.net',
+                        # TODO: switch to SSL Endpoint
+                        'dns': 'archiver.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'releng-production-archiver',
+                    #     'heroku_dyno_type': 'web',
+                    #     'url': 'https://archiver.mozilla-releng.net',
+                    #     # TODO: switch to SSL Endpoint
+                    #     'dns': 'archiver.mozilla-releng.net.herokudns.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-archiver',
-                'heroku_dyno_type': 'web',
-                'url': 'https://archiver.staging.mozilla-releng.net',
-                # TODO: switch to SSL Endpoint
-                'dns': 'archiver.staging.mozilla-releng.net.herokudns.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'releng-production-archiver',
-            #     'heroku_dyno_type': 'web',
-            #     'url': 'https://archiver.mozilla-releng.net',
-            #     # TODO: switch to SSL Endpoint
-            #     'dns': 'archiver.mozilla-releng.net.herokudns.com',
-            # },
-        },
+        ],
     },
     'releng-clobberer': {
         'checks': [
@@ -189,29 +201,33 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-clobberer',
-                'heroku_dyno_type': 'web',
-                'url': 'https://clobberer.testing.mozilla-releng.net',
-                # TODO: do testing and production have the same dns?
-                'dns': 'saitama-70467.herokussl.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-clobberer',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://clobberer.testing.mozilla-releng.net',
+                        # TODO: do testing and production have the same dns?
+                        'dns': 'saitama-70467.herokussl.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-clobberer',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://clobberer.staging.mozilla-releng.net',
+                        # TODO: do staging and production have the same dns?
+                        'dns': 'saitama-70467.herokussl.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'releng-production-clobberer',
+                    #     'heroku_dyno_type': 'web',
+                    #     'url': 'https://clobberer.mozilla-releng.net',
+                    #     'dns': 'saitama-70467.herokussl.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-clobberer',
-                'heroku_dyno_type': 'web',
-                'url': 'https://clobberer.staging.mozilla-releng.net',
-                # TODO: do staging and production have the same dns?
-                'dns': 'saitama-70467.herokussl.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'releng-production-clobberer',
-            #     'heroku_dyno_type': 'web',
-            #     'url': 'https://clobberer.mozilla-releng.net',
-            #     'dns': 'saitama-70467.herokussl.com',
-            # },
-        },
+        ],
     },
     'releng-docs': {
         'run': 'SPHINX',
@@ -219,24 +235,28 @@ PROJECTS_CONFIG = {
             'schema': 'http',
             'port': 7000,
         },
-        'deploy': 'S3',
-        'deploy_options': {
-            'testing': {
-                's3_bucket': 'releng-testing-docs',
-                'url': 'https://docs.testing.mozilla-releng.net',
-                'dns': 'd1sw5c8kdn03y.cloudfront.net.',
+        'deploys': [
+            {
+                'target': 'S3',
+                'options': {
+                    'testing': {
+                        's3_bucket': 'releng-testing-docs',
+                        'url': 'https://docs.testing.mozilla-releng.net',
+                        'dns': 'd1sw5c8kdn03y.cloudfront.net.',
+                    },
+                    'staging': {
+                        's3_bucket': 'releng-staging-docs',
+                        'url': 'https://docs.staging.mozilla-releng.net',
+                        'dns': 'd32jt14rospqzr.cloudfront.net.',
+                    },
+                    'production': {
+                        's3_bucket': 'releng-production-docs',
+                        'url': 'https://docs.mozilla-releng.net',
+                        'dns': 'd1945er7u4liht.cloudfront.net.',
+                    },
+                },
             },
-            'staging': {
-                's3_bucket': 'releng-staging-docs',
-                'url': 'https://docs.staging.mozilla-releng.net',
-                'dns': 'd32jt14rospqzr.cloudfront.net.',
-            },
-            'production': {
-                's3_bucket': 'releng-production-docs',
-                'url': 'https://docs.mozilla-releng.net',
-                'dns': 'd1945er7u4liht.cloudfront.net.',
-            },
-        }
+        ],
     },
     'releng-frontend': {
         'run': 'ELM',
@@ -253,37 +273,41 @@ PROJECTS_CONFIG = {
             'releng-notification-policy',
             'releng-notification-identity',
         ],
-        'deploy': 'S3',
-        'deploy_options': {
-            'testing': {
-                's3_bucket': 'releng-testing-frontend',
-                'url': 'https://testing.mozilla-releng.net',
-                'dns': 'd1l70lpksx3ik7.cloudfront.net.',
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                ],
+        'deploys': [
+            {
+                'target': 'S3',
+                'options': {
+                    'testing': {
+                        's3_bucket': 'releng-testing-frontend',
+                        'url': 'https://testing.mozilla-releng.net',
+                        'dns': 'd1l70lpksx3ik7.cloudfront.net.',
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                        ],
+                    },
+                    'staging': {
+                        's3_bucket': 'releng-staging-frontend',
+                        'url': 'https://staging.mozilla-releng.net',
+                        'dns': 'dpwmwa9tge2p3.cloudfront.net.',
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                        ],
+                    },
+                    'production': {
+                        's3_bucket': 'releng-production-frontend',
+                        'url': 'https://mozilla-releng.net',
+                        'dns': 'd1qqwps52z1e12.cloudfront.net.',
+                        'dns_domain': 'www.mozilla-releng.net',
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                        ],
+                    },
+                },
             },
-            'staging': {
-                's3_bucket': 'releng-staging-frontend',
-                'url': 'https://staging.mozilla-releng.net',
-                'dns': 'dpwmwa9tge2p3.cloudfront.net.',
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                ],
-            },
-            'production': {
-                's3_bucket': 'releng-production-frontend',
-                'url': 'https://mozilla-releng.net',
-                'dns': 'd1qqwps52z1e12.cloudfront.net.',
-                'dns_domain': 'www.mozilla-releng.net',
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                ],
-            },
-        },
+        ],
     },
     'releng-mapper': {
         'checks': [
@@ -297,30 +321,34 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-mapper',
-                'heroku_dyno_type': 'web',
-                'url': 'https://mapper.testing.mozilla-releng.net',
-                # TODO: switch to SSL Endpoint
-                'dns': 'mapper.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-mapper',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://mapper.testing.mozilla-releng.net',
+                        # TODO: switch to SSL Endpoint
+                        'dns': 'mapper.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-mapper',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://mapper.staging.mozilla-releng.net',
+                        # TODO: switch to SSL Endpoint
+                        'dns': 'mapper.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'releng-production-mapper',
+                    #     'heroku_dyno_type': 'web',
+                    #      # TODO: switch to SSL Endpoint
+                    #     'url': 'https://mapper.mozilla-releng.net',
+                    #     'dns': 'mapper.mozilla-releng.net.herokudns.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-mapper',
-                'heroku_dyno_type': 'web',
-                'url': 'https://mapper.staging.mozilla-releng.net',
-                # TODO: switch to SSL Endpoint
-                'dns': 'mapper.staging.mozilla-releng.net.herokudns.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'releng-production-mapper',
-            #     'heroku_dyno_type': 'web',
-            #      # TODO: switch to SSL Endpoint
-            #     'url': 'https://mapper.mozilla-releng.net',
-            #     'dns': 'mapper.mozilla-releng.net.herokudns.com',
-            # },
-        },
+        ],
     },
     'releng-tooltool': {
         'checks': [
@@ -334,27 +362,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-tooltool',
-                'heroku_dyno_type': 'web',
-                'url': 'https://tooltool.testing.mozilla-releng.net',
-                'dns': 'shizuoka-60622.herokussl.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-tooltool',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://tooltool.testing.mozilla-releng.net',
+                        'dns': 'shizuoka-60622.herokussl.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-tooltool',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://tooltool.staging.mozilla-releng.net',
+                        'dns': 'shizuoka-60622.herokussl.com',
+                    },
+                    'production': {
+                        'heroku_app': 'releng-production-tooltool',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://tooltool.mozilla-releng.net',
+                        'dns': 'kochi-11433.herokussl.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-tooltool',
-                'heroku_dyno_type': 'web',
-                'url': 'https://tooltool.staging.mozilla-releng.net',
-                'dns': 'shizuoka-60622.herokussl.com',
-            },
-            'production': {
-                'heroku_app': 'releng-production-tooltool',
-                'heroku_dyno_type': 'web',
-                'url': 'https://tooltool.mozilla-releng.net',
-                'dns': 'kochi-11433.herokussl.com',
-            },
-        },
+        ],
     },
     'releng-treestatus': {
         'checks': [
@@ -368,54 +400,66 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'releng-testing-treestatus',
-                'heroku_dyno_type': 'web',
-                'url': 'https://treestatus.testing.mozilla-releng.net',
-                # TODO: we need to change this to SSL Endpoint
-                'dns': 'treestatus.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'releng-testing-treestatus',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://treestatus.testing.mozilla-releng.net',
+                        # TODO: we need to change this to SSL Endpoint
+                        'dns': 'treestatus.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'releng-staging-treestatus',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://treestatus.staging.mozilla-releng.net',
+                        # TODO: we need to change this to SSL Endpoint
+                        'dns': 'treestatus.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    'production': {
+                        'heroku_app': 'releng-production-treestatus',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://treestatus.mozilla-releng.net',
+                        # TODO: this needs to be updated in mozilla-releng/build-cloud-tools
+                        'dns': 'kochi-31413.herokussl.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'releng-staging-treestatus',
-                'heroku_dyno_type': 'web',
-                'url': 'https://treestatus.staging.mozilla-releng.net',
-                # TODO: we need to change this to SSL Endpoint
-                'dns': 'treestatus.staging.mozilla-releng.net.herokudns.com',
-            },
-            'production': {
-                'heroku_app': 'releng-production-treestatus',
-                'heroku_dyno_type': 'web',
-                'url': 'https://treestatus.mozilla-releng.net',
-                # TODO: this needs to be updated in mozilla-releng/build-cloud-tools
-                'dns': 'kochi-31413.herokussl.com',
-            },
-        },
+        ],
     },
     'shipit-bot-uplift': {
         'checks': [
             ('Checking code quality', 'flake8'),
             ('Running tests', 'pytest tests/'),
         ],
-        'deploy': 'TASKCLUSTER_HOOK',
-        'deploy_options': {
-            'testing': {},
-            'staging': {},
-            'production': {},
-        },
+        'deploys': [
+            {
+                'target': 'TASKCLUSTER_HOOK',
+                'options': {
+                    'testing': {},
+                    'staging': {},
+                    'production': {},
+                },
+            },
+        ],
     },
     'shipit-code-coverage': {
         'checks': [
             ('Checking code quality', 'flake8'),
             ('Running tests', 'pytest tests/'),
         ],
-        'deploy': 'TASKCLUSTER_HOOK',
-        'deploy_options': {
-            'testing': {},
-            'staging': {},
-            'production': {},
-        },
+        'deploys': [
+            {
+                'target': 'TASKCLUSTER_HOOK',
+                'options': {
+                    'testing': {},
+                    'staging': {},
+                    'production': {},
+                },
+            },
+        ],
     },
     'shipit-code-coverage-backend': {
         'checks': [
@@ -429,27 +473,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'redis',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-codecoverage',
-                'heroku_dyno_type': 'web',
-                'url': 'https://coverage.testing.moz.tools',
-                'dns': 'coverage.testing.moz.tools.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-codecoverage',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://coverage.testing.moz.tools',
+                        'dns': 'coverage.testing.moz.tools.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-codecoverage',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://coverage.staging.moz.tools',
+                        'dns': 'coverage.staging.moz.tools.herokudns.com',
+                    },
+                    'production': {
+                        'heroku_app': 'shipit-production-codecoverage',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://coverage.moz.tools',
+                        'dns': 'coverage.moz.tools.herokudns.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-codecoverage',
-                'heroku_dyno_type': 'web',
-                'url': 'https://coverage.staging.moz.tools',
-                'dns': 'coverage.staging.moz.tools.herokudns.com',
-            },
-            'production': {
-                'heroku_app': 'shipit-production-codecoverage',
-                'heroku_dyno_type': 'web',
-                'url': 'https://coverage.moz.tools',
-                'dns': 'coverage.moz.tools.herokudns.com',
-            },
-        },
+        ],
     },
     'shipit-frontend': {
         'run': 'ELM',
@@ -462,50 +510,54 @@ PROJECTS_CONFIG = {
         'requires': [
             'shipit-uplift',
         ],
-        'deploy': 'S3',
-        'deploy_options': {
-            'testing': {
-                's3_bucket': 'shipit-testing-frontend',
-                'url': 'https://shipit.testing.mozilla-releng.net',
-                'dns': 'd2jpisuzgldax2.cloudfront.net.',
-                'envs': {
-                    'bugzilla-url': 'https://bugzilla.mozilla.org',
+        'deploys': [
+            {
+                'target': 'S3',
+                'options': {
+                    'testing': {
+                        's3_bucket': 'shipit-testing-frontend',
+                        'url': 'https://shipit.testing.mozilla-releng.net',
+                        'dns': 'd2jpisuzgldax2.cloudfront.net.',
+                        'envs': {
+                            'bugzilla-url': 'https://bugzilla.mozilla.org',
+                        },
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                            'https://bugzilla.mozilla.org',
+                        ],
+                    },
+                    'staging': {
+                        's3_bucket': 'shipit-staging-frontend',
+                        'url': 'https://shipit.staging.mozilla-releng.net',
+                        'dns': 'd2ld4e8bl8yd1l.cloudfront.net.',
+                        'envs': {
+                            'bugzilla-url': 'https://bugzilla.mozilla.org',
+                        },
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                            'https://bugzilla.mozilla.org',
+                            'https://uplift.shipit.staging.mozilla-releng.net',
+                        ],
+                    },
+                    'production': {
+                        's3_bucket': 'shipit-production-frontend',
+                        'url': 'https://shipit.mozilla-releng.net',
+                        'dns': 'dve8yd1431ifz.cloudfront.net.',
+                        'envs': {
+                            'bugzilla-url': 'https://bugzilla.mozilla.org',
+                        },
+                        'csp': [
+                            'https://login.taskcluster.net',
+                            'https://auth.taskcluster.net',
+                            'https://bugzilla.mozilla.org',
+                            'https://uplift.shipit.mozilla-releng.net',
+                        ],
+                    },
                 },
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                    'https://bugzilla.mozilla.org',
-                ],
             },
-            'staging': {
-                's3_bucket': 'shipit-staging-frontend',
-                'url': 'https://shipit.staging.mozilla-releng.net',
-                'dns': 'd2ld4e8bl8yd1l.cloudfront.net.',
-                'envs': {
-                    'bugzilla-url': 'https://bugzilla.mozilla.org',
-                },
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                    'https://bugzilla.mozilla.org',
-                    'https://uplift.shipit.staging.mozilla-releng.net',
-                ],
-            },
-            'production': {
-                's3_bucket': 'shipit-production-frontend',
-                'url': 'https://shipit.mozilla-releng.net',
-                'dns': 'dve8yd1431ifz.cloudfront.net.',
-                'envs': {
-                    'bugzilla-url': 'https://bugzilla.mozilla.org',
-                },
-                'csp': [
-                    'https://login.taskcluster.net',
-                    'https://auth.taskcluster.net',
-                    'https://bugzilla.mozilla.org',
-                    'https://uplift.shipit.mozilla-releng.net',
-                ],
-            },
-        },
+        ],
     },
     'shipit-pipeline': {
         'checks': [
@@ -519,27 +571,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-pipeline',
-                'heroku_dyno_type': 'web',
-                'url': 'https://pipeline.shipit.testing.mozilla-releng.net',
-                'dns': 'pipeline.shipit.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-pipeline',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://pipeline.shipit.testing.mozilla-releng.net',
+                        'dns': 'pipeline.shipit.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-pipeline',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://pipeline.shipit.staging.mozilla-releng.net',
+                        'dns': 'pipeline.shipit.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'shipit-production-pipeline',
+                    #     'heroku_dyno_type': 'web',
+                    #     'url': 'https://pipeline.shipit.mozilla-releng.net',
+                    #     'dns': 'pipeline.shipit.mozilla-releng.net.herokudns.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-pipeline',
-                'heroku_dyno_type': 'web',
-                'url': 'https://pipeline.shipit.staging.mozilla-releng.net',
-                'dns': 'pipeline.shipit.staging.mozilla-releng.net.herokudns.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'shipit-production-pipeline',
-            #     'heroku_dyno_type': 'web',
-            #     'url': 'https://pipeline.shipit.mozilla-releng.net',
-            #     'dns': 'pipeline.shipit.mozilla-releng.net.herokudns.com',
-            # },
-        },
+        ],
     },
     'shipit-pulse-listener': {
         'checks': [
@@ -547,21 +603,25 @@ PROJECTS_CONFIG = {
             ('Running tests', 'pytest tests/'),
         ],
         'requires': [],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-pulse-listener',
-                'heroku_dyno_type': 'worker',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-pulse-listener',
+                        'heroku_dyno_type': 'worker',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-pulse-listener',
+                        'heroku_dyno_type': 'worker',
+                    },
+                    'production': {
+                        'heroku_app': 'shipit-production-pulse-listen',
+                        'heroku_dyno_type': 'worker',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-pulse-listener',
-                'heroku_dyno_type': 'worker',
-            },
-            'production': {
-                'heroku_app': 'shipit-production-pulse-listen',
-                'heroku_dyno_type': 'worker',
-            },
-        },
+        ],
     },
     'shipit-signoff': {
         'checks': [
@@ -579,39 +639,47 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-signoff',
-                'heroku_dyno_type': 'web',
-                'url': 'https://signoff.shipit.testing.mozilla-releng.net',
-                'dns': 'signoff.shipit.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-signoff',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://signoff.shipit.testing.mozilla-releng.net',
+                        'dns': 'signoff.shipit.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-signoff',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://signoff.shipit.staging.mozilla-releng.net',
+                        'dns': 'signoff.shipit.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'shipit-production-signoff',
+                    #     'heroku_dyno_type': 'web',
+                    #     'url': 'https://signoff.shipit.mozilla-releng.net',
+                    #     'dns': 'signoff.shipit.mozilla-releng.net.herokudns.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-signoff',
-                'heroku_dyno_type': 'web',
-                'url': 'https://signoff.shipit.staging.mozilla-releng.net',
-                'dns': 'signoff.shipit.staging.mozilla-releng.net.herokudns.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'shipit-production-signoff',
-            #     'heroku_dyno_type': 'web',
-            #     'url': 'https://signoff.shipit.mozilla-releng.net',
-            #     'dns': 'signoff.shipit.mozilla-releng.net.herokudns.com',
-            # },
-        },
+        ],
     },
     'shipit-static-analysis': {
         'checks': [
             ('Checking code quality', 'flake8'),
             ('Running tests', 'pytest tests/'),
         ],
-        'deploy': 'TASKCLUSTER_HOOK',
-        'deploy_options': {
-            'testing': {},
-            'staging': {},
-            'production': {},
-        },
+        'deploys': [
+            {
+                'target': 'TASKCLUSTER_HOOK',
+                'options': {
+                    'testing': {},
+                    'staging': {},
+                    'production': {},
+                },
+            },
+        ]
     },
     'shipit-taskcluster': {
         'checks': [
@@ -625,27 +693,31 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-taskcluster',
-                'heroku_dyno_type': 'web',
-                'url': 'https://taskcluster.shipit.testing.mozilla-releng.net',
-                'dns': 'taskcluster.shipit.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-taskcluster',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://taskcluster.shipit.testing.mozilla-releng.net',
+                        'dns': 'taskcluster.shipit.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-taskcluster',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://taskcluster.shipit.staging.mozilla-releng.net',
+                        'dns': 'taskcluster.shipit.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    # 'production': {
+                    #     'heroku_app': 'shipit-production-taskcluster',
+                    #     'heroku_dyno_type': 'web',
+                    #     'url': 'https://taskcluster.shipit.mozilla-releng.net',
+                    #     'dns': 'taskcluster.shipit.mozilla-releng.net.herokudns.com',
+                    # },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-taskcluster',
-                'heroku_dyno_type': 'web',
-                'url': 'https://taskcluster.shipit.staging.mozilla-releng.net',
-                'dns': 'taskcluster.shipit.staging.mozilla-releng.net.herokudns.com',
-            },
-            # 'production': {
-            #     'heroku_app': 'shipit-production-taskcluster',
-            #     'heroku_dyno_type': 'web',
-            #     'url': 'https://taskcluster.shipit.mozilla-releng.net',
-            #     'dns': 'taskcluster.shipit.mozilla-releng.net.herokudns.com',
-            # },
-        },
+        ],
     },
     'shipit-uplift': {
         'checks': [
@@ -660,27 +732,31 @@ PROJECTS_CONFIG = {
             'postgresql',
             'redis',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-uplift',
-                'heroku_dyno_type': 'web',
-                'url': 'https://uplift.shipit.testing.mozilla-releng.net',
-                'dns': 'uplift.shipit.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-uplift',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://uplift.shipit.testing.mozilla-releng.net',
+                        'dns': 'uplift.shipit.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-uplift',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://uplift.shipit.staging.mozilla-releng.net',
+                        'dns': 'uplift.shipit.staging.mozilla-releng.net.herokudns.com',
+                    },
+                    'production': {
+                        'heroku_app': 'shipit-production-uplift',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://uplift.shipit.mozilla-releng.net',
+                        'dns': 'uplift.shipit.mozilla-releng.net.herokudns.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-uplift',
-                'heroku_dyno_type': 'web',
-                'url': 'https://uplift.shipit.staging.mozilla-releng.net',
-                'dns': 'uplift.shipit.staging.mozilla-releng.net.herokudns.com',
-            },
-            'production': {
-                'heroku_app': 'shipit-production-uplift',
-                'heroku_dyno_type': 'web',
-                'url': 'https://uplift.shipit.mozilla-releng.net',
-                'dns': 'uplift.shipit.mozilla-releng.net.herokudns.com',
-            },
-        },
+        ],
     },
     'shipit-workflow': {
         'checks': [
@@ -694,22 +770,26 @@ PROJECTS_CONFIG = {
         'requires': [
             'postgresql',
         ],
-        'deploy': 'HEROKU',
-        'deploy_options': {
-            'testing': {
-                'heroku_app': 'shipit-testing-workflow',
-                'heroku_dyno_type': 'web',
-                'url': 'https://shipit-workflow.testing.mozilla-releng.net',
-                # TODO: we need to change this to SSL Endpoint
-                'dns': 'shipit-workflow.testing.mozilla-releng.net.herokudns.com',
+        'deploys': [
+            {
+                'target': 'HEROKU',
+                'options': {
+                    'testing': {
+                        'heroku_app': 'shipit-testing-workflow',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://shipit-workflow.testing.mozilla-releng.net',
+                        # TODO: we need to change this to SSL Endpoint
+                        'dns': 'shipit-workflow.testing.mozilla-releng.net.herokudns.com',
+                    },
+                    'staging': {
+                        'heroku_app': 'shipit-staging-workflow',
+                        'heroku_dyno_type': 'web',
+                        'url': 'https://shipit-workflow.staging.mozilla-releng.net',
+                        # TODO: we need to change this to SSL Endpoint
+                        'dns': 'shipit-workflow.staging.mozilla-releng.net.herokudns.com',
+                    },
+                },
             },
-            'staging': {
-                'heroku_app': 'shipit-staging-workflow',
-                'heroku_dyno_type': 'web',
-                'url': 'https://shipit-workflow.staging.mozilla-releng.net',
-                # TODO: we need to change this to SSL Endpoint
-                'dns': 'shipit-workflow.staging.mozilla-releng.net.herokudns.com',
-            },
-        },
+        ],
     },
 }

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -91,18 +91,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-notif-policy',
                         'heroku_dyno_type': 'web',
                         'url': 'https://policy.notification.testing.mozilla-releng.net',
                         'dns': 'policy.notification.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-notif-policy',
                         'heroku_dyno_type': 'web',
                         'url': 'https://policy.notification.staging.mozilla-releng.net',
                         'dns': 'policy.notification.staging.mozilla-releng.net.herokudns.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-production-notif-policy',
                         'heroku_dyno_type': 'web',
                         'url': 'https://policy.notification.mozilla-releng.net',
@@ -129,18 +132,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-notif-identity',
                         'heroku_dyno_type': 'web',
                         'url': 'https://identity.notification.testing.mozilla-releng.net',
                         'dns': 'identity.notification.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-notif-identity',
                         'heroku_dyno_type': 'web',
                         'url': 'https://identity.notification.staging.mozilla-releng.net',
                         'dns': 'identity.notification.staging.mozilla-releng.net.herokudns.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-production-notif-ident',
                         'heroku_dyno_type': 'web',
                         'url': 'https://identity.notification.mozilla-releng.net',
@@ -167,6 +173,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-archiver',
                         'heroku_dyno_type': 'web',
                         'url': 'https://archiver.testing.mozilla-releng.net',
@@ -174,6 +181,7 @@ PROJECTS_CONFIG = {
                         'dns': 'archiver.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-archiver',
                         'heroku_dyno_type': 'web',
                         'url': 'https://archiver.staging.mozilla-releng.net',
@@ -181,6 +189,7 @@ PROJECTS_CONFIG = {
                         'dns': 'archiver.staging.mozilla-releng.net.herokudns.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'releng-production-archiver',
                     #     'heroku_dyno_type': 'web',
                     #     'url': 'https://archiver.mozilla-releng.net',
@@ -208,6 +217,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-clobberer',
                         'heroku_dyno_type': 'web',
                         'url': 'https://clobberer.testing.mozilla-releng.net',
@@ -215,6 +225,7 @@ PROJECTS_CONFIG = {
                         'dns': 'saitama-70467.herokussl.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-clobberer',
                         'heroku_dyno_type': 'web',
                         'url': 'https://clobberer.staging.mozilla-releng.net',
@@ -222,6 +233,7 @@ PROJECTS_CONFIG = {
                         'dns': 'saitama-70467.herokussl.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'releng-production-clobberer',
                     #     'heroku_dyno_type': 'web',
                     #     'url': 'https://clobberer.mozilla-releng.net',
@@ -328,6 +340,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-mapper',
                         'heroku_dyno_type': 'web',
                         'url': 'https://mapper.testing.mozilla-releng.net',
@@ -335,6 +348,7 @@ PROJECTS_CONFIG = {
                         'dns': 'mapper.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-mapper',
                         'heroku_dyno_type': 'web',
                         'url': 'https://mapper.staging.mozilla-releng.net',
@@ -342,6 +356,7 @@ PROJECTS_CONFIG = {
                         'dns': 'mapper.staging.mozilla-releng.net.herokudns.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'releng-production-mapper',
                     #     'heroku_dyno_type': 'web',
                     #      # TODO: switch to SSL Endpoint
@@ -369,18 +384,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-tooltool',
                         'heroku_dyno_type': 'web',
                         'url': 'https://tooltool.testing.mozilla-releng.net',
                         'dns': 'shizuoka-60622.herokussl.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-tooltool',
                         'heroku_dyno_type': 'web',
                         'url': 'https://tooltool.staging.mozilla-releng.net',
                         'dns': 'shizuoka-60622.herokussl.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-production-tooltool',
                         'heroku_dyno_type': 'web',
                         'url': 'https://tooltool.mozilla-releng.net',
@@ -407,6 +425,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-testing-treestatus',
                         'heroku_dyno_type': 'web',
                         'url': 'https://treestatus.testing.mozilla-releng.net',
@@ -414,6 +433,7 @@ PROJECTS_CONFIG = {
                         'dns': 'treestatus.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-staging-treestatus',
                         'heroku_dyno_type': 'web',
                         'url': 'https://treestatus.staging.mozilla-releng.net',
@@ -421,6 +441,7 @@ PROJECTS_CONFIG = {
                         'dns': 'treestatus.staging.mozilla-releng.net.herokudns.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'releng-production-treestatus',
                         'heroku_dyno_type': 'web',
                         'url': 'https://treestatus.mozilla-releng.net',
@@ -440,9 +461,15 @@ PROJECTS_CONFIG = {
             {
                 'target': 'TASKCLUSTER_HOOK',
                 'options': {
-                    'testing': {},
-                    'staging': {},
-                    'production': {},
+                    'testing': {
+                        'nix_path_attribute': 'deploy.testing',
+                    },
+                    'staging': {
+                        'nix_path_attribute': 'deploy.staging',
+                    },
+                    'production': {
+                        'nix_path_attribute': 'deploy.production',
+                    },
                 },
             },
         ],
@@ -456,9 +483,15 @@ PROJECTS_CONFIG = {
             {
                 'target': 'TASKCLUSTER_HOOK',
                 'options': {
-                    'testing': {},
-                    'staging': {},
-                    'production': {},
+                    'testing': {
+                        'nix_path_attribute': 'deploy.testing',
+                    },
+                    'staging': {
+                        'nix_path_attribute': 'deploy.staging',
+                    },
+                    'production': {
+                        'nix_path_attribute': 'deploy.production',
+                    },
                 },
             },
         ],
@@ -480,18 +513,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-codecoverage',
                         'heroku_dyno_type': 'web',
                         'url': 'https://coverage.testing.moz.tools',
                         'dns': 'coverage.testing.moz.tools.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-codecoverage',
                         'heroku_dyno_type': 'web',
                         'url': 'https://coverage.staging.moz.tools',
                         'dns': 'coverage.staging.moz.tools.herokudns.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-production-codecoverage',
                         'heroku_dyno_type': 'web',
                         'url': 'https://coverage.moz.tools',
@@ -578,18 +614,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-pipeline',
                         'heroku_dyno_type': 'web',
                         'url': 'https://pipeline.shipit.testing.mozilla-releng.net',
                         'dns': 'pipeline.shipit.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-pipeline',
                         'heroku_dyno_type': 'web',
                         'url': 'https://pipeline.shipit.staging.mozilla-releng.net',
                         'dns': 'pipeline.shipit.staging.mozilla-releng.net.herokudns.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'shipit-production-pipeline',
                     #     'heroku_dyno_type': 'web',
                     #     'url': 'https://pipeline.shipit.mozilla-releng.net',
@@ -610,14 +649,17 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-pulse-listener',
                         'heroku_dyno_type': 'worker',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-pulse-listener',
                         'heroku_dyno_type': 'worker',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-production-pulse-listen',
                         'heroku_dyno_type': 'worker',
                     },
@@ -646,18 +688,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-signoff',
                         'heroku_dyno_type': 'web',
                         'url': 'https://signoff.shipit.testing.mozilla-releng.net',
                         'dns': 'signoff.shipit.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-signoff',
                         'heroku_dyno_type': 'web',
                         'url': 'https://signoff.shipit.staging.mozilla-releng.net',
                         'dns': 'signoff.shipit.staging.mozilla-releng.net.herokudns.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'shipit-production-signoff',
                     #     'heroku_dyno_type': 'web',
                     #     'url': 'https://signoff.shipit.mozilla-releng.net',
@@ -676,9 +721,15 @@ PROJECTS_CONFIG = {
             {
                 'target': 'TASKCLUSTER_HOOK',
                 'options': {
-                    'testing': {},
-                    'staging': {},
-                    'production': {},
+                    'testing': {
+                        'nix_path_attribute': 'deploy.testing',
+                    },
+                    'staging': {
+                        'nix_path_attribute': 'deploy.staging',
+                    },
+                    'production': {
+                        'nix_path_attribute': 'deploy.production',
+                    },
                 },
             },
         ]
@@ -700,18 +751,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-taskcluster',
                         'heroku_dyno_type': 'web',
                         'url': 'https://taskcluster.shipit.testing.mozilla-releng.net',
                         'dns': 'taskcluster.shipit.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-taskcluster',
                         'heroku_dyno_type': 'web',
                         'url': 'https://taskcluster.shipit.staging.mozilla-releng.net',
                         'dns': 'taskcluster.shipit.staging.mozilla-releng.net.herokudns.com',
                     },
                     # 'production': {
+                    #     'nix_path_attribute': 'docker',
                     #     'heroku_app': 'shipit-production-taskcluster',
                     #     'heroku_dyno_type': 'web',
                     #     'url': 'https://taskcluster.shipit.mozilla-releng.net',
@@ -739,18 +793,21 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-uplift',
                         'heroku_dyno_type': 'web',
                         'url': 'https://uplift.shipit.testing.mozilla-releng.net',
                         'dns': 'uplift.shipit.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-uplift',
                         'heroku_dyno_type': 'web',
                         'url': 'https://uplift.shipit.staging.mozilla-releng.net',
                         'dns': 'uplift.shipit.staging.mozilla-releng.net.herokudns.com',
                     },
                     'production': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-production-uplift',
                         'heroku_dyno_type': 'web',
                         'url': 'https://uplift.shipit.mozilla-releng.net',
@@ -777,6 +834,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-workflow',
                         'heroku_dyno_type': 'web',
                         'url': 'https://shipit-workflow.testing.mozilla-releng.net',
@@ -784,6 +842,7 @@ PROJECTS_CONFIG = {
                         'dns': 'shipit-workflow.testing.mozilla-releng.net.herokudns.com',
                     },
                     'staging': {
+                        'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-staging-workflow',
                         'heroku_dyno_type': 'web',
                         'url': 'https://shipit-workflow.staging.mozilla-releng.net',

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -77,7 +77,7 @@ def get_deploy_task(index,
 
     scopes = []
 
-    nix_path_attribute = deploy_options.get('nix_path_attribute')
+    nix_path_attribute = deploy_options.get('nix_path_attribute', '')
     if nix_path_attribute:
         nix_path_attribute = ' ({})'.format(nix_path_attribute)
 

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -350,7 +350,7 @@ def cmd(ctx,
                             project_name,
                             please_cli.config.PROJECTS_CONFIG[project_name].get('requires', []),
                             deploy['target'],
-                            deploy['options'],
+                            deploy['options'][channel],
                         ))
 
     click.echo(' => Creating taskcluster tasks definitions')
@@ -401,7 +401,7 @@ def cmd(ctx,
             github_commit,
             channel,
             taskcluster_secret,
-            './please -vv tools maintanance:on ' + ' '.join(deploy_projects),
+            './please -vv tools maintanance:on ' + ' '.join(list(set([i[0] for i in projects_to_deploy]))),
             {
                 'name': '2. Maintanance ON',
                 'description': '',
@@ -442,7 +442,7 @@ def cmd(ctx,
             github_commit,
             channel,
             taskcluster_secret,
-            './please -vv tools maintanance:off ' + ' '.join(deploy_projects),
+            './please -vv tools maintanance:off ' + ' '.join(list(set([i[0] for i in projects_to_deploy]))),
             {
                 'name': '4. Maintanance OFF',
                 'description': '',
@@ -460,11 +460,14 @@ def cmd(ctx,
         for task_id, task in tasks:
             click.echo(' => %s (%s)' % (task['metadata']['name'], task_id))
             click.echo('    dependencies:')
+            deps = []
             for dep in task['dependencies']:
                 depName = "0. Decision task"
                 if dep in tasks2:
                     depName = tasks2[dep]['metadata']['name']
-                click.echo('      - %s (%s)' % (depName, dep))
+                    deps.append('      - %s (%s)' % (depName, dep))
+            for dep in sorted(deps):
+                click.echo(dep)
     else:
         for task_id, task in tasks:
             taskcluster_queue.createTask(task_id, task)

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -325,7 +325,7 @@ def cmd(ctx,
         if not project_exists_in_cache:
             build_projects.append(project)
 
-    projects_to_deploy = {}
+    projects_to_deploy = []
 
     if channel in please_cli.config.DEPLOY_CHANNELS:
         click.echo(' => Checking which project needs to be redeployed')

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -16,6 +16,9 @@ import click_spinner
 import please_cli.config
 
 
+PROJECTS = list(set(please_cli.config.PROJECTS) - set(please_cli.config.DEV_PROJECTS))
+
+
 def get_build_task(index,
                    project,
                    task_group_id,
@@ -289,7 +292,6 @@ def cmd(ctx,
     """A tool to be ran on each commit.
     """
 
-
     taskcluster_secret = 'repo:github.com/mozilla-releng/services:branch:' + channel
     if pull_request is not None:
         taskcluster_secret = 'repo:github.com/mozilla-releng/services:pull-request'
@@ -308,7 +310,7 @@ def cmd(ctx,
     click.echo(' => Checking cache which project needs to be rebuilt')
     build_projects = []
     project_hashes = dict()
-    for project in sorted(please_cli.config.PROJECTS):
+    for project in sorted(PROJECTS):
         click.echo('     => ' + project)
         project_exists_in_cache, project_hash = ctx.invoke(
             please_cli.check_cache.cmd,
@@ -337,16 +339,16 @@ def cmd(ctx,
             if deployed_projects == project_hashes[project_name]:
                 continue
 
-            if project_name not in PROJECTS_CONFIG or \
-                    'deploys' not in PROJECTS_CONFIG[project_name]:
+            if project_name not in please_cli.config.PROJECTS_CONFIG or \
+                    'deploys' not in please_cli.config.PROJECTS_CONFIG[project_name]:
                 continue
 
-            for deploy in PROJECTS_CONFIG[project_name]['deploys']:
+            for deploy in please_cli.config.PROJECTS_CONFIG[project_name]['deploys']:
                 for deploy_channel in deploy['options']:
                     if channel == deploy_channel:
                         projects_to_deploy.append((
                             project_name,
-                            PROJECTS_CONFIG[project_name].get('requires', []),
+                            please_cli.config.PROJECTS_CONFIG[project_name].get('requires', []),
                             deploy['target'],
                             deploy['options'],
                         ))

--- a/lib/please_cli/please_cli/deploy.py
+++ b/lib/please_cli/please_cli/deploy.py
@@ -114,77 +114,83 @@ def cmd_S3(ctx,
                taskcluster_access_token=taskcluster_access_token,
                interactive=interactive,
                )
-    project_path = os.path.realpath(os.path.join(
-        please_cli.config.TMP_DIR,
-        'result-build-{}-channel-{}'.format(project, channel),
-    ))
 
-    # 2. create temporary copy of project
-    click.echo(' => Copying build artifacs to temporary location ... ', nl=False)
-    with click_spinner.spinner():
-        if not os.path.exists(please_cli.config.TMP_DIR):
-            os.makedirs(please_cli.config.TMP_DIR)
-        tmp_dir = tempfile.mkdtemp(
-            prefix='copy-of-result-{}-'.format(project),
-            dir=please_cli.config.TMP_DIR,
+    for item in os.listdir(please_cli.config.TMP_DIR):
+
+        if not item.startswith('result-build-{}-'.format(project)):
+            continue
+
+        project_path = os.path.realpath(os.path.join(
+            please_cli.config.TMP_DIR,
+            item,
+        ))
+
+        # 2. create temporary copy of project
+        click.echo(' => Copying build artifacs to temporary location ... ', nl=False)
+        with click_spinner.spinner():
+            if not os.path.exists(please_cli.config.TMP_DIR):
+                os.makedirs(please_cli.config.TMP_DIR)
+            tmp_dir = tempfile.mkdtemp(
+                prefix='copy-of-result-{}-'.format(project),
+                dir=please_cli.config.TMP_DIR,
+            )
+            shutil.rmtree(tmp_dir)
+            shutil.copytree(project_path, tmp_dir, copy_function=shutil.copy)
+        please_cli.utils.check_result(
+            0,
+            'Copied build artifacs to temporary location: {}'.format(tmp_dir),
+            ask_for_details=interactive,
         )
-        shutil.rmtree(tmp_dir)
-        shutil.copytree(project_path, tmp_dir, copy_function=shutil.copy)
-    please_cli.utils.check_result(
-        0,
-        'Copied build artifacs to temporary location: {}'.format(tmp_dir),
-        ask_for_details=interactive,
-    )
 
-    # 3. apply csp and flags to index.html
-    click.echo(' => Applying CSP and environment flags to index.html ... ', nl=False)
-    with click_spinner.spinner():
-        index_html_file = os.path.join(tmp_dir, 'index.html')
-        with io.open(index_html_file, 'r', encoding='utf-8') as f:
-            index_html = f.read()
-        if csp:
-            index_html = index_html.replace(
-                'font-src \'self\';',
-                'font-src \'self\'; connect-src {};'.format(' '.join(csp)),
-            )
-        if env:
-            index_html = index_html.replace(
-                '<body',
-                '<body ' + (' '.join([
-                    'data-{}="{}"'.format(*[j.strip() for j in i.split(':', 1)])
-                    for i in env
-                ])),
-            )
+        # 3. apply csp and flags to index.html
+        click.echo(' => Applying CSP and environment flags to index.html ... ', nl=False)
+        with click_spinner.spinner():
+            index_html_file = os.path.join(tmp_dir, 'index.html')
+            with io.open(index_html_file, 'r', encoding='utf-8') as f:
+                index_html = f.read()
+            if csp:
+                index_html = index_html.replace(
+                    'font-src \'self\';',
+                    'font-src \'self\'; connect-src {};'.format(' '.join(csp)),
+                )
+            if env:
+                index_html = index_html.replace(
+                    '<body',
+                    '<body ' + (' '.join([
+                        'data-{}="{}"'.format(*[j.strip() for j in i.split(':', 1)])
+                        for i in env
+                    ])),
+                )
 
-        os.chmod(index_html_file, 0o755)
-        with io.open(index_html_file, 'w', encoding='utf-8') as f:
-            f.write(index_html)
-    please_cli.utils.check_result(
-        0,
-        'Applied CSP and environment flags to index.html',
-        ask_for_details=interactive,
-    )
+            os.chmod(index_html_file, 0o755)
+            with io.open(index_html_file, 'w', encoding='utf-8') as f:
+                f.write(index_html)
+        please_cli.utils.check_result(
+            0,
+            'Applied CSP and environment flags to index.html',
+            ask_for_details=interactive,
+        )
 
-    # 4. sync to S3
-    click.echo(' => Syncing to S3  ... ', nl=False)
-    with click_spinner.spinner():
-        os.environ['AWS_ACCESS_KEY_ID'] = AWS_ACCESS_KEY_ID
-        os.environ['AWS_SECRET_ACCESS_KEY'] = AWS_SECRET_ACCESS_KEY
-        aws = awscli.clidriver.create_clidriver().main
-        aws([
-            's3',
-            'sync',
-            '--quiet',
-            '--delete',
-            '--acl', 'public-read',
-            tmp_dir,
-            's3://' + s3_bucket,
-        ])
-    please_cli.utils.check_result(
-        0,
-        'Synced {} to S3 bucket {}'.format(project, s3_bucket),
-        ask_for_details=interactive,
-    )
+        # 4. sync to S3
+        click.echo(' => Syncing to S3  ... ', nl=False)
+        with click_spinner.spinner():
+            os.environ['AWS_ACCESS_KEY_ID'] = AWS_ACCESS_KEY_ID
+            os.environ['AWS_SECRET_ACCESS_KEY'] = AWS_SECRET_ACCESS_KEY
+            aws = awscli.clidriver.create_clidriver().main
+            aws([
+                's3',
+                'sync',
+                '--quiet',
+                '--delete',
+                '--acl', 'public-read',
+                tmp_dir,
+                's3://' + s3_bucket,
+            ])
+        please_cli.utils.check_result(
+            0,
+            'Synced {} to S3 bucket {}'.format(project, s3_bucket),
+            ask_for_details=interactive,
+        )
 
 
 @click.command()
@@ -276,26 +282,31 @@ def cmd_HEROKU(ctx,
                interactive=interactive,
                )
 
-    project_path = os.path.realpath(os.path.join(
-        please_cli.config.TMP_DIR,
-        'result-build-{}-channel-{}'.format(project, channel),
-    ))
+    for item in os.listdir(please_cli.config.TMP_DIR):
 
-    click.echo(' => Pushing {} to heroku ... '.format(project), nl=False)
-    with click_spinner.spinner():
-        push.registry.push(
-            push.image.spec(project_path),
-            "https://registry.heroku.com",
-            heroku_username,
-            heroku_api_token,
-            heroku_app + "/" + heroku_dyno_type,
-            "latest",
+        if not item.startswith('result-build-{}-'.format(project)):
+            continue
+
+        project_path = os.path.realpath(os.path.join(
+            please_cli.config.TMP_DIR,
+            item,
+        ))
+
+        click.echo(' => Pushing {} to heroku ... '.format(project), nl=False)
+        with click_spinner.spinner():
+            push.registry.push(
+                push.image.spec(project_path),
+                "https://registry.heroku.com",
+                heroku_username,
+                heroku_api_token,
+                heroku_app + "/" + heroku_dyno_type,
+                "latest",
+            )
+        please_cli.utils.check_result(
+            0,
+            'Pushed {} to heroku.'.format(project),
+            ask_for_details=interactive,
         )
-    please_cli.utils.check_result(
-        0,
-        'Pushed {} to heroku.'.format(project),
-        ask_for_details=interactive,
-    )
 
 
 @click.command()
@@ -404,65 +415,71 @@ def cmd_TASKCLUSTER_HOOK(ctx,
                taskcluster_access_token=taskcluster_access_token,
                interactive=interactive,
                )
-    project_path = os.path.realpath(os.path.join(
-        please_cli.config.TMP_DIR,
-        'result-build-{}-channel-{}'.format(project, channel),
-    ))
 
-    with open(project_path) as f:
-        hook = json.load(f)
+    for item in os.listdir(please_cli.config.TMP_DIR):
 
-    image = hook.get('task', {}).get('payload', {}).get('image', '')
-    if image.startswith('/nix/store'):
+        if not item.startswith('result-build-{}-'.format(project)):
+            continue
 
-        image_tag = '-'.join(reversed(image[11:-7].split('-', 1)))
-        click.echo(' => Uploading docker image `{}:{}` ... '.format(docker_repo, image_tag), nl=False)
-        with click_spinner.spinner():
-            push.registry.push(
-                push.image.spec(image),
-                please_cli.config.DOCKER_REGISTRY,
-                docker_username,
-                docker_password,
-                docker_repo,
-                image_tag,
+        project_path = os.path.realpath(os.path.join(
+            please_cli.config.TMP_DIR,
+            item,
+        ))
+
+        with open(project_path) as f:
+            hook = json.load(f)
+
+        image = hook.get('task', {}).get('payload', {}).get('image', '')
+        if image.startswith('/nix/store'):
+
+            image_tag = '-'.join(reversed(image[11:-7].split('-', 1)))
+            click.echo(' => Uploading docker image `{}:{}` ... '.format(docker_repo, image_tag), nl=False)
+            with click_spinner.spinner():
+                push.registry.push(
+                    push.image.spec(image),
+                    please_cli.config.DOCKER_REGISTRY,
+                    docker_username,
+                    docker_password,
+                    docker_repo,
+                    image_tag,
+                )
+
+            please_cli.utils.check_result(
+                0,
+                'Pushed {}:{} docker image.'.format(docker_repo, image_tag),
+                ask_for_details=interactive,
             )
 
+            hook['task']['payload']['image'] = '{}:{}'.format(docker_repo, image_tag)
+
+        if hook_exists:
+            click.echo(' => Updating hook `{}/{}` ... '.format(hook_group_id, hook_id), nl=False)
+            with click_spinner.spinner():
+                try:
+                    hooks_tool.updateHook(hook_group_id, hook_id, hook)
+                    result = 0
+                    output = ''
+                except taskcluster.exceptions.TaskclusterRestFailure as e:
+                    log.exception(e)
+                    output = str(e)
+                    result = 1
+        else:
+            click.echo(' => Creating hook `{}/{}` ... '.format(hook_group_id, hook_id), nl=False)
+            with click_spinner.spinner():
+                try:
+                    hooks_tool.createHook(hook_group_id, hook_id, hook)
+                    result = 0
+                    output = ''
+                except taskcluster.exceptions.TaskclusterRestFailure as e:
+                    log.exception(e)
+                    output = str(e)
+                    result = 1
+
         please_cli.utils.check_result(
-            0,
-            'Pushed {}:{} docker image.'.format(docker_repo, image_tag),
+            result,
+            output,
             ask_for_details=interactive,
         )
-
-        hook['task']['payload']['image'] = '{}:{}'.format(docker_repo, image_tag)
-
-    if hook_exists:
-        click.echo(' => Updating hook `{}/{}` ... '.format(hook_group_id, hook_id), nl=False)
-        with click_spinner.spinner():
-            try:
-                hooks_tool.updateHook(hook_group_id, hook_id, hook)
-                result = 0
-                output = ''
-            except taskcluster.exceptions.TaskclusterRestFailure as e:
-                log.exception(e)
-                output = str(e)
-                result = 1
-    else:
-        click.echo(' => Creating hook `{}/{}` ... '.format(hook_group_id, hook_id), nl=False)
-        with click_spinner.spinner():
-            try:
-                hooks_tool.createHook(hook_group_id, hook_id, hook)
-                result = 0
-                output = ''
-            except taskcluster.exceptions.TaskclusterRestFailure as e:
-                log.exception(e)
-                output = str(e)
-                result = 1
-
-    please_cli.utils.check_result(
-        result,
-        output,
-        ask_for_details=interactive,
-    )
 
 
 @click.command()
@@ -564,33 +581,39 @@ def cmd_DOCKERHUB(ctx,
                taskcluster_access_token=taskcluster_access_token,
                interactive=interactive,
               )
-    project_path = os.path.realpath(os.path.join(
-        please_cli.config.TMP_DIR,
-        'result-build-{}-channel-{}'.format(project, channel),
-    ))
 
-    spec = push.image.spec(project_path)
-    # Stable tag, e.g. shipit-workflow-staging
-    image_tag = docker_image_tag_format.format(project=project, channel=channel)
-    project_basename = os.path.basename(project_path)
-    # remove the docker-image-mozilla- prefix and the extension
-    tag_base = project_basename.replace('docker-image-mozilla-', '').replace('.tar.gz', '')
-    # Puth the hash to the end of the tag
-    image_tag_versioned = '-'.join(reversed(tag_base.split('-', 1)))
-    for tag in (image_tag_versioned, image_tag):
-        click.echo(' => Uploading docker image `{}:{}` ... '.format(docker_repo, tag), nl=False)
-        with click_spinner.spinner():
-            push.registry.push(
-                spec,
-                docker_registry,
-                docker_username,
-                docker_password,
-                docker_repo,
-                tag,
+    for item in os.listdir(please_cli.config.TMP_DIR):
+
+        if not item.startswith('result-build-{}-'.format(project)):
+            continue
+
+        project_path = os.path.realpath(os.path.join(
+            please_cli.config.TMP_DIR,
+            item,
+        ))
+
+        spec = push.image.spec(project_path)
+        # Stable tag, e.g. shipit-workflow-staging
+        image_tag = docker_image_tag_format.format(project=project, channel=channel)
+        project_basename = os.path.basename(project_path)
+        # remove the docker-image-mozilla- prefix and the extension
+        tag_base = project_basename.replace('docker-image-mozilla-', '').replace('.tar.gz', '')
+        # Puth the hash to the end of the tag
+        image_tag_versioned = '-'.join(reversed(tag_base.split('-', 1)))
+        for tag in (image_tag_versioned, image_tag):
+            click.echo(' => Uploading docker image `{}:{}` ... '.format(docker_repo, tag), nl=False)
+            with click_spinner.spinner():
+                push.registry.push(
+                    spec,
+                    docker_registry,
+                    docker_username,
+                    docker_password,
+                    docker_repo,
+                    tag,
+                )
+
+            please_cli.utils.check_result(
+                0,
+                'Pushed {}:{} docker image.'.format(docker_repo, tag),
+                ask_for_details=interactive,
             )
-
-        please_cli.utils.check_result(
-            0,
-            'Pushed {}:{} docker image.'.format(docker_repo, tag),
-            ask_for_details=interactive,
-        )

--- a/lib/please_cli/please_cli/nagios_config.py
+++ b/lib/please_cli/please_cli/nagios_config.py
@@ -32,16 +32,19 @@ def cmd(channel):
         channels = [channel]
 
 
-    for project_id in sorted(please_cli.config.PROJECTS_CONFIG.keys()):
-        project = please_cli.config.PROJECTS_CONFIG[project_id].get('deploy_options')
+    for project_name in sorted(please_cli.config.PROJECTS):
+        deployments = please_cli.config.PROJECTS_CONFIG.get(project_name, dict()).get('deploys', [])
 
-        if project:
-            for channel in sorted(channels):
+        for deployment in deployments:
+            channels = deployment.get('options', dict()).keys()
 
-                if channel not in project or 'url' not in project[channel]:
+            for channel in channels:
+                deployment_options = deployment['options'][channel]
+
+                if 'url' not in deployment_options:
                     continue
 
-                project_url = project[channel]['url']
+                project_url = deployment_options['url']
                 project_url = project_url.lstrip('https')
                 project_url = project_url.lstrip('http')
                 project_url = project_url.lstrip('://')
@@ -49,6 +52,5 @@ def cmd(channel):
                 contact_groups = 'shipitalerts'
                 if channel == 'production':
                     contact_groups = 'build'
-
 
                 click.echo(NAGIOS_TEMPLATE % (project_url, contact_groups))

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -837,12 +837,6 @@ in rec {
 
           docker = self_docker;
 
-          deploy = {
-            testing = self_docker;
-            staging = self_docker;
-            production = self_docker;
-          };
-
         } // passthru;
       };
     in self;


### PR DESCRIPTION
This commit does NOT implement sub-projects.

What it brings is a possibility to deploy similar nix derivations (variations) to multiple different locations.

As an example it could be that project needs to deploy to HEROKU web dyno and also to HEROKU worker dyno. It would deploy very similar docker image where majority of the code can be cached.

This feature should not increase build times.