### PR TITLE
Import fix

### DIFF
--- a/lib/backend_common/backend_common/auth0.py
+++ b/lib/backend_common/backend_common/auth0.py
@@ -23,7 +23,7 @@ import urllib.parse
 
 import flask
 import flask_oidc
-import jose
+import jose.jwt
 import requests
 
 import cli_common.log


### PR DESCRIPTION
Changing the import from `from jose import jwt` to `import jose`
introduced errors like:

AttributeError: module 'jose' has no attribute 'jwt'