### PR TITLE
shipit_code_coverage, shipit_uplift: Make the GitHub repository a configurable secret

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -416,7 +416,7 @@ PROJECTS_CONFIG = {
         'deploy_options': {
             'testing': {},
             'staging': {},
-            # 'production': {},
+            'production': {},
         },
     },
     'shipit-frontend': {

--- a/src/shipit_code_coverage/shipit_code_coverage/secrets.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/secrets.py
@@ -9,6 +9,7 @@ from shipit_code_coverage import config
 
 class Secrets(dict):
     COVERALLS_TOKEN = 'COVERALLS_TOKEN'
+    CODECOV_REPO = 'CODECOV_REPO'
     CODECOV_TOKEN = 'CODECOV_TOKEN'
     CODECOV_ACCESS_TOKEN = 'CODECOV_ACCESS_TOKEN'
     GECKO_DEV_USER = 'GECKO_DEV_USER'
@@ -23,6 +24,7 @@ class Secrets(dict):
             required=(
                 Secrets.APP_CHANNEL,
                 Secrets.COVERALLS_TOKEN,
+                Secrets.CODECOV_REPO,
                 Secrets.CODECOV_TOKEN,
                 Secrets.CODECOV_ACCESS_TOKEN,
             ),

--- a/src/shipit_code_coverage/shipit_code_coverage/uploader.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/uploader.py
@@ -63,7 +63,7 @@ def codecov(data, commit_sha, flags=None):
 
 def get_latest_codecov():
     def get_latest_codecov_int():
-        r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev?access_token={}'.format(secrets[secrets.CODECOV_ACCESS_TOKEN]))
+        r = requests.get('https://codecov.io/api/gh/{}?access_token={}'.format(secrets[secrets.CODECOV_REPO], secrets[secrets.CODECOV_ACCESS_TOKEN]))
         r.raise_for_status()
         return r.json()['commit']['commitid']
 
@@ -75,7 +75,7 @@ def codecov_wait(commit):
         pass
 
     def check_codecov_job():
-        r = requests.get('https://codecov.io/api/gh/marco-c/gecko-dev/commit/{}?access_token={}'.format(commit, secrets[secrets.CODECOV_ACCESS_TOKEN]))
+        r = requests.get('https://codecov.io/api/gh/{}/commit/{}?access_token={}'.format(secrets[secrets.CODECOV_REPO], commit, secrets[secrets.CODECOV_ACCESS_TOKEN]))  # noqa
         r.raise_for_status()
         totals = r.json()['commit']['totals']
         if totals is None:

--- a/src/shipit_uplift/shipit_uplift/coverage.py
+++ b/src/shipit_uplift/shipit_uplift/coverage.py
@@ -80,7 +80,7 @@ class CoverallsCoverage(Coverage):
 
     @staticmethod
     async def get_latest_build():
-        async with CoverallsCoverage._get('/github/marco-c/gecko-dev.json?page=1') as r:
+        async with CoverallsCoverage._get('/github/{}.json?page=1'.format(secrets.CODECOV_REPO)) as r:
             builds = (await r.json())['builds']
 
         return await get_mercurial_commit(builds[0]['commit_sha']), await get_mercurial_commit(builds[1]['commit_sha'])
@@ -89,7 +89,7 @@ class CoverallsCoverage(Coverage):
 class CodecovCoverage(Coverage):
     @staticmethod
     def _get(url=''):
-        return aiohttp.request('GET', 'https://codecov.io/api/gh/marco-c/gecko-dev{}?access_token={}'.format(url, secrets.CODECOV_ACCESS_TOKEN))
+        return aiohttp.request('GET', 'https://codecov.io/api/gh/{}{}?access_token={}'.format(secrets.CODECOV_REPO, url, secrets.CODECOV_ACCESS_TOKEN))
 
     @staticmethod
     @alru_cache(maxsize=2048)

--- a/src/shipit_uplift/shipit_uplift/secrets.py
+++ b/src/shipit_uplift/shipit_uplift/secrets.py
@@ -19,3 +19,4 @@ secrets = cli_common.taskcluster.get_secrets(
 
 REDIS_URL = secrets['REDIS_URL'] if 'REDIS_URL' in secrets else 'redis://localhost:6379'
 CODECOV_ACCESS_TOKEN = secrets['CODECOV_ACCESS_TOKEN'] if 'CODECOV_ACCESS_TOKEN' in secrets else ''
+CODECOV_REPO = secrets['CODECOV_REPO'] if 'CODECOV_REPO' in secrets else 'marco-c/gecko-dev'


### PR DESCRIPTION
With this, we'll be able to enable shipit_code_coverage on production.