### PR TITLE
shipit-static-analysis: Fix lint issue building with double path variable

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -161,7 +161,7 @@ class MozLint(object):
 
         # Mozlint uses both full & relative path to index issues
         return [
-            MozLintIssue(path, **issue)
+            MozLintIssue(**issue)
             for p in (path, full_path)
             for issue in payload.get(p, [])
         ]


### PR DESCRIPTION
From [Sentry Error](https://sentry.prod.mozaws.net/operations/mozilla-releng-services/issues/3848806/)