### PR TITLE
shipit-static-analysis: Do not check clang-tidy -* is present.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -187,6 +187,7 @@ class ClangTidy(object):
             check['name']
             for check in settings.clang_checkers
             if not len(fnmatch.filter(available_checks, check['name'])) > 0
+            and check['name'] != '-*'  # Special check -* is not listed by clang-tidy
         ]
 
 

--- a/src/shipit_static_analysis/tests/mocks/config.yaml
+++ b/src/shipit_static_analysis/tests/mocks/config.yaml
@@ -1,6 +1,8 @@
 ---
 target: obj-x86_64-pc-linux-gnu
 clang_checkers:
+ - name: -*
+   publish: !!bool no
  - name: clang-analyzer-deadcode.DeadStores
    publish: !!bool yes
  - name: clang-analyzer-security.*


### PR DESCRIPTION
[Sentry Error](https://sentry.prod.mozaws.net/operations/mozilla-releng-services/issues/3608196/)

Fixes #1060.