### PR TITLE
Update Spidermonkey task names in trychooser

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -102,7 +102,10 @@
                 <label><input type="checkbox" name="platform" value="android-aarch64">android-aarch64 (Android 5.0)</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="sm-arm-sim">Spidermonkey arm-sim</label>
+                <label><input type="checkbox" name="platform" value="sm-arm-sim-linux32">Spidermonkey ARM32 simulator</label>
+            </li>
+            <li>
+                <label><input type="checkbox" name="platform" value="sm-arm64-sim-linux64">Spidermonkey ARM64 simulator</label>
             </li>
             <!-- TODO: Currently not supported, enable when it is
             <li>
@@ -110,13 +113,13 @@
             </li>
             -->
             <li>
-                <label><input type="checkbox" name="platform" value="sm-compacting">Spidermonkey compacting</label>
+                <label><input type="checkbox" name="platform" value="sm-compacting-linux64">Spidermonkey compacting linux64</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="sm-plain">Spidermonkey plain</label>
-            </li>
+                <label><input type="checkbox" name="platform" value="sm-plain-linux64">Spidermonkey plain linux64</label>
+            </li>    
             <li>
-                <label><input type="checkbox" name="platform" value="sm-rootanalysis">Spidermonkey rootanalysis</label>
+                <label><input type="checkbox" name="platform" value="sm-rootanalysis-linux64">Spidermonkey rootanalysis linux64</label>
             </li>
             </ul>
             </div>


### PR DESCRIPTION
- These task names were not working anymore, probably due to recent changes; it is now necessary to explicitly set the architecture's name.
- Also added the ARM64 simulator task, which is now interesting to us.