### PR TITLE
shipit_pulse_listener: Don't fail, but print a warning, when MH_BRANCH is not defined

### DIFF
--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -177,6 +177,10 @@ class HookCodeCoverage(PulseHook):
         return False
 
     def is_mozilla_central_task(self, task):
+        if 'MH_BRANCH' not in task['task']['payload']['env']:
+            logger.warn('Received groupResolved notification for a task without MH_BRANCH', task_id=task['status']['taskId'])
+            return False
+
         branch = task['task']['payload']['env']['MH_BRANCH']
 
         if branch != 'mozilla-central':


### PR DESCRIPTION
Fixes #1114.

I haven't added a test because I want to see when this happens first and then write a test for a real case.
We don't have Sentry for shipit-pulse-listener so I can't inspect the error that happened today.