### PR TITLE
shipit_pulse_listener: Remove old task check, as it's no longer required with idempotent coverage task

### DIFF
--- a/src/shipit_pulse_listener/requirements.txt
+++ b/src/shipit_pulse_listener/requirements.txt
@@ -1,3 +1,1 @@
 -e ./../../lib/cli_common[pulse,taskcluster,log] #egg=mozilla-cli-common
-
-pytz

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
-from datetime import datetime
-from datetime import timedelta
 
-import dateutil.parser
-import pytz
 import requests
 
 from cli_common.log import get_logger
@@ -164,18 +160,6 @@ class HookCodeCoverage(PulseHook):
     def is_coverage_task(self, task):
         return any(task['task']['metadata']['name'].startswith(s) for s in ['build-linux64-ccov', 'build-win64-ccov'])
 
-    def as_utc(self, d):
-        if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
-            return pytz.utc.localize(d)
-        return d.astimezone(pytz.utc)
-
-    def is_old_task(self, task):
-        for run in task['status']['runs']:
-            run_date = self.as_utc(dateutil.parser.parse(run['resolved']))
-            if run_date < self.as_utc(datetime.utcnow() - timedelta(1)):
-                return True
-        return False
-
     def is_mozilla_central_task(self, task):
         if 'MH_BRANCH' not in task['task']['payload']['env']:
             logger.warn('Received groupResolved notification for a task without MH_BRANCH', task_id=task['status']['taskId'])
@@ -236,10 +220,6 @@ class HookCodeCoverage(PulseHook):
 
         build_task = self.get_build_task_in_group(taskGroupId)
         if build_task is None:
-            return None
-
-        if self.is_old_task(build_task):
-            logger.info('Received groupResolved notification for an old task', group=taskGroupId)
             return None
 
         if not self.is_mozilla_central_task(build_task):

--- a/src/shipit_pulse_listener/tests/test_code_coverage_listener.py
+++ b/src/shipit_pulse_listener/tests/test_code_coverage_listener.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-from datetime import datetime
-from datetime import timedelta
 
 import responses
 
@@ -60,39 +58,6 @@ def test_is_coverage_task():
         }
     }
     assert not hook.is_coverage_task(nocov_task)
-
-
-def test_is_old_task():
-    hook = HookCodeCoverage({
-      'hookId': 'shipit-staging-code-coverage'
-    })
-
-    new_task = {
-        'status': {
-            'runs': [{
-                'resolved': datetime.utcnow().strftime('%Y-%m-%d'),
-            }]
-        }
-    }
-    assert not hook.is_old_task(new_task)
-
-    old_task = {
-        'status': {
-            'runs': [{
-                'resolved': (datetime.utcnow() - timedelta(2)).strftime('%Y-%m-%d'),
-            }]
-        }
-    }
-    assert hook.is_old_task(old_task)
-
-    old_task = {
-        'status': {
-            'runs': [{
-                'resolved': '2017-07-31T19:32:04.855Z',
-            }]
-        }
-    }
-    assert hook.is_old_task(old_task)
 
 
 def test_get_build_task_in_group():
@@ -173,14 +138,7 @@ def test_wrong_branch():
 @responses.activate
 def test_success():
     with open(os.path.join(FIXTURES_DIR, 'RS0UwZahQ_qAcdZzEb_Y9g.json')) as f:
-
-        # Update resolved date
-        mockup = json.load(f)
-        now = datetime.now().isoformat()
-        for i, task in enumerate(mockup['tasks']):
-            mockup['tasks'][i]['status']['runs'][0]['resolved'] = now
-
-        responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task-group/RS0UwZahQ_qAcdZzEb_Y9g/list?limit=200', json=mockup, status=200, match_querystring=True)  # noqa
+        responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task-group/RS0UwZahQ_qAcdZzEb_Y9g/list?limit=200', json=json.load(f), status=200, match_querystring=True)  # noqa
 
     hook = HookCodeCoverage({
       'hookId': 'shipit-staging-code-coverage'


### PR DESCRIPTION
Depends on #1122.

Fixes #1115.