### PR TITLE
shipit-workflow: filter releases API

### DIFF
--- a/src/shipit_workflow/shipit_workflow/api.py
+++ b/src/shipit_workflow/shipit_workflow/api.py
@@ -89,11 +89,14 @@ def add_release(body):
         raise BadRequest(description=e.description)
 
 
-def list_releases(full=False):
+def list_releases(product=None, branch=None, status=['scheduled']):
     session = flask.g.db.session
     releases = session.query(Release)
-    if not full:
-        releases = releases.filter(Release.status == 'scheduled')
+    if product:
+        releases = releases.filter(Release.product == product)
+    if branch:
+        releases = releases.filter(Release.branch == branch)
+    releases = releases.filter(Release.status.in_(status))
     return [r.json for r in releases.all()]
 
 

--- a/src/shipit_workflow/shipit_workflow/api.yml
+++ b/src/shipit_workflow/shipit_workflow/api.yml
@@ -37,8 +37,16 @@ paths:
       operationId: shipit_workflow.api.list_releases
       parameters:
       - in: query
-        name: full
-        type: boolean
+        name: product
+        type: string
+      - in: query
+        name: branch
+        type: string
+      - in: query
+        name: status
+        type: array
+        items:
+          type: string
       responses:
         200:
           description: A list of releases


### PR DESCRIPTION
This will be used by the UI to find shipped releases in order to
generate a list of suggested partials.