### PR TITLE
shipit_code_coverage: Look for debug build first and fallback on opt build if the debug build doesn't exist

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -12,6 +12,10 @@ index_base = 'https://index.taskcluster.net/v1/'
 queue_base = 'https://queue.taskcluster.net/v1/'
 
 
+class TaskclusterException(Exception):
+    pass
+
+
 def get_task(branch, revision, platform):
     if platform == 'linux':
         # A few days after https://bugzilla.mozilla.org/show_bug.cgi?id=1457393 is fixed,
@@ -21,7 +25,7 @@ def get_task(branch, revision, platform):
     elif platform == 'win':
         platform_names = ['win64-ccov-debug']
     else:
-        raise Exception('Unsupported platform: %s' % platform)
+        raise TaskclusterException('Unsupported platform: %s' % platform)
 
     while True:
         platform_name = platform_names.pop(0)
@@ -32,10 +36,10 @@ def get_task(branch, revision, platform):
                 return task['taskId']
             else:
                 if task['code'] == 'ResourceNotFound':
-                    raise Exception('Code coverage build failed and was not indexed.')
+                    raise TaskclusterException('Code coverage build failed and was not indexed.')
                 else:
-                    raise Exception('Unknown TaskCluster index error.')
-        except Exception:
+                    raise TaskclusterException('Unknown TaskCluster index error.')
+        except TaskclusterException:
             if len(platform_names) == 0:
                 raise
 

--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -27,8 +27,7 @@ def get_task(branch, revision, platform):
     else:
         raise TaskclusterException('Unsupported platform: %s' % platform)
 
-    while True:
-        platform_name = platform_names.pop(0)
+    for i, platform_name in enumerate(platform_names):
         try:
             r = requests.get(index_base + 'task/gecko.v2.{}.revision.{}.firefox.{}'.format(branch, revision, platform_name))
             task = r.json()
@@ -40,7 +39,7 @@ def get_task(branch, revision, platform):
                 else:
                     raise TaskclusterException('Unknown TaskCluster index error.')
         except TaskclusterException:
-            if len(platform_names) == 0:
+            if i == len(platform_names) - 1:
                 raise
 
 

--- a/src/shipit_code_coverage/tests/test_taskcluster.py
+++ b/src/shipit_code_coverage/tests/test_taskcluster.py
@@ -25,7 +25,7 @@ def test_get_task_details(LINUX_TASK_ID, LINUX_TASK):
 
 @responses.activate
 def test_get_task(LINUX_TASK_ID, LATEST_LINUX, WIN_TASK_ID, LATEST_WIN):
-    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt', json=LATEST_LINUX, status=200)  # noqa
+    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-debug', json=LATEST_LINUX, status=200)  # noqa
     assert taskcluster.get_task('mozilla-central', 'b2a9a4bb5c94de179ae7a3f52fde58c0e2897498', 'linux') == LINUX_TASK_ID
 
     responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.916103b8675d9fdb28b891cac235d74f9f475942.firefox.win64-ccov-debug', json=LATEST_WIN, status=200)  # noqa
@@ -34,9 +34,10 @@ def test_get_task(LINUX_TASK_ID, LATEST_LINUX, WIN_TASK_ID, LATEST_WIN):
 
 @responses.activate
 def test_get_task_not_found(TASK_NOT_FOUND):
+    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-debug', json=TASK_NOT_FOUND, status=404)  # noqa
     responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt', json=TASK_NOT_FOUND, status=404)  # noqa
 
-    with pytest.raises(Exception, message='Code coverage build failed and was not indexed.'):
+    with pytest.raises(taskcluster.TaskclusterException, message='Code coverage build failed and was not indexed.'):
         taskcluster.get_task('mozilla-central', 'b2a9a4bb5c94de179ae7a3f52fde58c0e2897498', 'linux')
 
 
@@ -44,10 +45,18 @@ def test_get_task_not_found(TASK_NOT_FOUND):
 def test_get_task_failure(TASK_NOT_FOUND):
     err = TASK_NOT_FOUND.copy()
     err['code'] = 'RandomError'
+    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-debug', json=err, status=500)  # noqa
     responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt', json=err, status=500)  # noqa
 
-    with pytest.raises(Exception, message='Unknown TaskCluster index error.'):
+    with pytest.raises(taskcluster.TaskclusterException, message='Unknown TaskCluster index error.'):
         taskcluster.get_task('mozilla-central', 'b2a9a4bb5c94de179ae7a3f52fde58c0e2897498', 'linux')
+
+
+@responses.activate
+def test_get_task_opt_fallback(TASK_NOT_FOUND, LINUX_TASK_ID, LATEST_LINUX):
+    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-debug', json=TASK_NOT_FOUND, status=404)  # noqa
+    responses.add(responses.GET, 'https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.revision.b2a9a4bb5c94de179ae7a3f52fde58c0e2897498.firefox.linux64-ccov-opt', json=LATEST_LINUX, status=200)  # noqa
+    assert taskcluster.get_task('mozilla-central', 'b2a9a4bb5c94de179ae7a3f52fde58c0e2897498', 'linux') == LINUX_TASK_ID
 
 
 @responses.activate


### PR DESCRIPTION
The code coverage build is a debug build, but named as an opt build.
In https://bugzilla.mozilla.org/show_bug.cgi?id=1457393, we are renaming it to identify it as a debug build. For a while, the code coverage task will have to support both names.