### PR TITLE
shipit_code_coverage: Actually use the filtered task list when downloading artifacts

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
@@ -103,7 +103,7 @@ class ArtifactsHandler(object):
                     download_tasks[(chunk_name, platform_name)] = test_task
 
         with ThreadPoolExecutorResult() as executor:
-            for test_task in test_tasks:
+            for test_task in download_tasks.values():
                 executor.submit(self.download, test_task)
 
         logger.info('Code coverage artifacts downloaded')

--- a/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/artifacts.py
@@ -83,7 +83,7 @@ class ArtifactsHandler(object):
         download_tasks = {}
         for test_task in test_tasks:
             status = test_task['status']['state']
-            assert status in ALL_STATUSES
+            assert status in ALL_STATUSES, "State '{}' not recognized".format(status)
 
             chunk_name = taskcluster.get_chunk(test_task['task']['metadata']['name'])
             platform_name = taskcluster.get_platform(test_task['task']['metadata']['name'])

--- a/src/shipit_code_coverage/tests/test_artifacts.py
+++ b/src/shipit_code_coverage/tests/test_artifacts.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import itertools
 import os
 from unittest import mock
 
 import pytest
+import responses
 
 from shipit_code_coverage.artifacts import ArtifactsHandler
 
@@ -83,3 +85,103 @@ def test_download(mocked_download_artifact, mocked_get_task_artifact, TEST_TASK_
         'AN1M9SW0QY6DZT6suL3zlQ',
         'public/test_info/code-coverage-jsvm.zip',
     )
+
+
+# In the download_all tests, we want to make sure the relative ordering of the tasks
+# in the Taskcluster group does not affect the result, so we test with all possible
+# orderings of several possible states.
+def _group_tasks():
+    task_state_groups = [
+        [
+            ('test-linux64-ccov/opt-mochitest-devtools-chrome-e10s-4', 'exception'),
+            ('test-linux64-ccov/opt-mochitest-devtools-chrome-e10s-4', 'failed'),
+            ('test-linux64-ccov/opt-mochitest-devtools-chrome-e10s-4', 'completed'),
+        ],
+        [
+            ('test-linux64-ccov/opt-xpcshell-4', 'exception'),
+            ('test-linux64-ccov/opt-xpcshell-4', 'failed'),
+        ],
+        [
+            ('test-windows10-64-ccov/debug-talos-dromaeojs-e10s', 'failed'),
+            ('test-windows10-64-ccov/debug-talos-dromaeojs-e10s', 'completed'),
+        ],
+        [
+            ('test-linux64-ccov/opt-cppunit', 'exception'),
+            ('test-linux64-ccov/opt-cppunit', 'completed'),
+        ],
+        [
+            ('test-linux64-stylo-disabled/debug-crashtest-e10s', 'completed'),
+        ]
+    ]
+
+    # Transform a task_name and state into an object like the ones returned by Taskcluster.
+    def build_task(task_state):
+        task_name = task_state[0]
+        state = task_state[1]
+        return {
+            'status': {
+                'taskId': task_name + '-' + state,
+                'state': state,
+            },
+            'task': {
+                'metadata': {
+                    'name': task_name
+                },
+            }
+        }
+
+    # Generate all possible permutations of task_name - state.
+    task_state_groups_permutations = [list(itertools.permutations(task_state_group)) for task_state_group in task_state_groups]
+
+    # Generate the product of all possible permutations.
+    for ordering in itertools.product(*task_state_groups_permutations):
+        yield {
+            'taskGroupId': 'aPt9FbIdQwmhwDIPDYLuaw',
+            'tasks': [build_task(task_state) for sublist in ordering for task_state in sublist],
+        }
+
+
+@responses.activate
+def test_download_all(LINUX_TASK_ID, LINUX_TASK, GROUP_TASKS_1, GROUP_TASKS_2, FAKE_ARTIFACTS_DIR):
+    responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task/{}'.format(LINUX_TASK_ID), json=LINUX_TASK, status=200)
+    for group_tasks in _group_tasks():
+        responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task-group/aPt9FbIdQwmhwDIPDYLuaw/list', json=group_tasks, status=200)
+
+        a = ArtifactsHandler({'linux': LINUX_TASK_ID}, [], parent_dir=FAKE_ARTIFACTS_DIR)
+
+        downloaded = set()
+
+        def mock_download(task):
+            downloaded.add(task['status']['taskId'])
+        a.download = mock_download
+
+        a.download_all()
+
+        assert downloaded == set([
+            'test-linux64-ccov/opt-mochitest-devtools-chrome-e10s-4-completed',
+            'test-linux64-ccov/opt-xpcshell-4-failed',
+            'test-windows10-64-ccov/debug-talos-dromaeojs-e10s-completed',
+            'test-linux64-ccov/opt-cppunit-completed',
+        ])
+
+
+@responses.activate
+def test_download_all_ignore(LINUX_TASK_ID, LINUX_TASK, GROUP_TASKS_1, GROUP_TASKS_2, FAKE_ARTIFACTS_DIR):
+    responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task/{}'.format(LINUX_TASK_ID), json=LINUX_TASK, status=200)
+    for group_tasks in _group_tasks():
+        responses.add(responses.GET, 'https://queue.taskcluster.net/v1/task-group/aPt9FbIdQwmhwDIPDYLuaw/list', json=group_tasks, status=200)
+
+        a = ArtifactsHandler({'linux': LINUX_TASK_ID}, ['talos', 'xpcshell'], parent_dir=FAKE_ARTIFACTS_DIR)
+
+        downloaded = set()
+
+        def mock_download(task):
+            downloaded.add(task['status']['taskId'])
+        a.download = mock_download
+
+        a.download_all()
+
+        assert downloaded == set([
+            'test-linux64-ccov/opt-mochitest-devtools-chrome-e10s-4-completed',
+            'test-linux64-ccov/opt-cppunit-completed',
+        ])


### PR DESCRIPTION
We are filtering the tasks to download in download_all, but then using the original list when actually downloading the artifacts.