### PR TITLE
shipit_code_coverage: Fix variable name in report_generators

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/report_generators.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/report_generators.py
@@ -130,20 +130,20 @@ class ZeroCov(object):
 
         filesinfo = self.get_fileinfo(zero_coverage_functions.keys())
 
-        zero_coverage_files = []
+        zero_coverage_info = []
         for fname, functions in zero_coverage_functions.items():
             info = filesinfo[fname]
             info.update({'name': fname,
                          'funcs': len(functions),
                          'uncovered': fname in zero_coverage_files})
-            zero_coverage_files.append(info)
+            zero_coverage_info.append(info)
 
             with open(os.path.join(out_dir, 'zero_coverage_functions/%s.json' % fname.replace('/', '_')), 'w') as f:
                 json.dump(functions, f)
 
         zero_coverage_report = {'github_revision': gitrev,
                                 'hg_revision': hgrev,
-                                'files': zero_coverage_files}
+                                'files': zero_coverage_info}
 
         with open(os.path.join(out_dir, 'zero_coverage_report.json'), 'w') as f:
             json.dump(zero_coverage_report, f)

--- a/src/shipit_code_coverage/tests/test_report_generators.py
+++ b/src/shipit_code_coverage/tests/test_report_generators.py
@@ -70,3 +70,4 @@ def test_zero_coverage(tmpdir,
         assert found_item['last_push_date'] == exp_item['last_push_date']
         assert found_item['size'] == exp_item['size']
         assert found_item['commits'] == exp_item['commits']
+        assert found_item['uncovered'] == exp_item['uncovered']


### PR DESCRIPTION
Bad variable rename in https://github.com/mozilla-releng/services/commit/432ca36d23aa0016151e5d55085a763956c64b84