### PR TITLE
please: Use host networking instead of binding ports

### DIFF
--- a/lib/please_cli/please_cli/run.py
+++ b/lib/please_cli/please_cli/run.py
@@ -66,7 +66,7 @@ def cmd(ctx, project, quiet, nix_shell,
 
     host = run_options.get('host', 'localhost')
     if please_cli.config.IN_DOCKER:
-        host = run_options.get('host', '0.0.0.0')
+        host = run_options.get('host', '127.0.0.1')
     port = str(run_options.get('port', 8000))
     schema = 'https://'
     project_name = project.replace('-', '_')

--- a/please
+++ b/please
@@ -45,8 +45,7 @@ else
             --volume="$(pwd)":/app \
             --volume=/var/run/docker.sock:/var/run/docker.sock \
             --workdir=/app \
-            -p 7000:7000 \
-            -p 8000-8100:8000-8100 \
+            --network="host" \
             mozillareleng/services:base-`cat ./VERSION`
       else
         docker start $DOCKER_NAME


### PR DESCRIPTION
This method has several advantages:

1. Does not bind unecessary ports
2. Previously binded port are automatically binded on `localhost`, so the urls continue working as is
3. The docker container also have access to the host computer network as `localhost`, so we can use SSH tunneling (needed for `shipit-code-coverage-backend` development)
4. Seems to avoid the port binding error sometimes encountered

Tested on releng_docs, shipit-uplift, postgresql, shipit-frontend, shipit-static-analysis, shipit-code-coverage-backend.

We should probably push this to staging before merging, in order to test the Taskcluster compatibility

Additional official dock on [--network=host](https://docs.docker.com/network/host/)