### PR TITLE
shipit-workflow: filter by build_number

### DIFF
--- a/src/shipit_workflow/shipit_workflow/api.py
+++ b/src/shipit_workflow/shipit_workflow/api.py
@@ -81,7 +81,8 @@ def add_release(body):
         raise BadRequest(description=e.description)
 
 
-def list_releases(product=None, branch=None, version=None, status=['scheduled']):
+def list_releases(product=None, branch=None, version=None, build_number=None,
+                  status=['scheduled']):
     session = flask.g.db.session
     releases = session.query(Release)
     if product:
@@ -90,6 +91,11 @@ def list_releases(product=None, branch=None, version=None, status=['scheduled'])
         releases = releases.filter(Release.branch == branch)
     if version:
         releases = releases.filter(Release.version == version)
+        if build_number:
+            releases = releases.filter(Release.build_number == build_number)
+    elif build_number:
+        raise BadRequest(description='Filtering by build_number without version'
+                         ' is not supported.')
     releases = releases.filter(Release.status.in_(status))
     return [r.json for r in releases.all()]
 

--- a/src/shipit_workflow/shipit_workflow/api.yml
+++ b/src/shipit_workflow/shipit_workflow/api.yml
@@ -46,6 +46,9 @@ paths:
         name: version
         type: string
       - in: query
+        name: build_number
+        type: integer
+      - in: query
         name: status
         type: array
         items:


### PR DESCRIPTION
In order to fetch l10n info for partials, we need to know the revision of a particular build. This way we can stop using *_RELEASE tags in the UI.