### PR TITLE
shipit-workflow: fix taskGroupId input

### DIFF
--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -106,6 +106,7 @@ def generate_action_task(action_name, action_task_input, actions):
     context.update({
         'input': action_task_input,
         'taskGroupId': action_task_id,
+        'ownTaskId': action_task_id,
         'taskId': None,
         'task': None,
     })

--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -105,7 +105,7 @@ def generate_action_task(action_name, action_task_input, actions):
     action_task_id = slugid.nice().decode('utf-8')
     context.update({
         'input': action_task_input,
-        'ownTaskId': action_task_id,
+        'taskGroupId': action_task_id,
         'taskId': None,
         'task': None,
     })


### PR DESCRIPTION
We renamed `ownTaskId` to `taskGroupId` recently.