### PR TITLE
releng-docs: Fix shipit-static-analysis docs

### DIFF
--- a/src/releng_docs/projects/shipit-static-analysis.rst
+++ b/src/releng_docs/projects/shipit-static-analysis.rst
@@ -72,7 +72,7 @@ Run the following (where ``XXX`` is the Taskcluster access token):
 .. code-block:: shell
 
   ./please shell shipit-static-analysis \
-    --taskcluster-client-id=mozilla-auth0/ad|Mozilla-LDAP|bastien/static-analysis-dev \
+    --taskcluster-client-id="mozilla-auth0/ad|Mozilla-LDAP|bastien/static-analysis-dev" \
     --taskcluster-access-token=XXX
 
 Once the initial build finishes, you should get a green Nix shell, running in ``/app/src/shipit_static_analysis``.

--- a/src/releng_docs/projects/shipit-static-analysis.rst
+++ b/src/releng_docs/projects/shipit-static-analysis.rst
@@ -172,6 +172,7 @@ Finally, you can run the bot with this command (in the Nix Shell):
 
 .. code-block:: shell
 
+  mkdir -p /app/tmp
   shipit-static-analysis \
     --taskcluster-secret=repo:github.com/mozilla-releng/services:branch:master \
     --cache-root=/app/tmp


### PR DESCRIPTION
Fixes:

```
[nix-shell:/app/src/shipit_static_analysis]$ shipit-static-analysis \
>   --taskcluster-secret=repo:github.com/mozilla-releng/services:branch:staging \
>   --cache-root=/app/tmp
shipit_static_analysis.config: Loaded configuration from mozilla-central
Traceback (most recent call last):
  File "/tmp/tmp.v87BoCgR0a/bin/shipit-static-analysis", line 11, in <module>
    load_entry_point('shipit-static-analysis', 'console_scripts', 'shipit-static-analysis')()
  File "/nix/store/wy78qnkvl1lw7p8vw4zpgqhp642w38vj-python3.5-click-6.7/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/wy78qnkvl1lw7p8vw4zpgqhp642w38vj-python3.5-click-6.7/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/nix/store/wy78qnkvl1lw7p8vw4zpgqhp642w38vj-python3.5-click-6.7/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/wy78qnkvl1lw7p8vw4zpgqhp642w38vj-python3.5-click-6.7/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/51m1kki8ri1acd0m1b5z7zdgwwicmyrx-python3.5-python3.5-mozilla-cli-common-1.0.0/lib/python3.5/site-packages/cli_common/cli.py", line 35, in wrapper
    return func(*args, **kwargs)
  File "/nix/store/0ivvxa7gli2lhsxsscgvycbzsbjj5l8w-python3-3.5.5/lib/python3.5/contextlib.py", line 30, in inner
    return func(*args, **kwds)
  File "/app/src/shipit_static_analysis/shipit_static_analysis/cli.py", line 75, in main
    settings.setup(secrets['APP_CHANNEL'], cache_root, secrets['PUBLICATION'])
  File "/app/src/shipit_static_analysis/shipit_static_analysis/config.py", line 61, in setup
    assert os.path.isdir(cache_root)
AssertionError
```