### PR TITLE
shipit-workflow: do not set ACTION_TASK_GROUP_ID

### DIFF
--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -117,6 +117,4 @@ def generate_action_task(action_name, action_task_input, actions):
 
 def render_action_task(task, context, action_task_id):
     action_task = jsone.render(task, context)
-    # override ACTION_TASK_GROUP_ID, so we know the new ID in advance
-    action_task['payload']['env']['ACTION_TASK_GROUP_ID'] = action_task_id
     return action_task


### PR DESCRIPTION
CoT fails to validate action tasks with ACTION_TASK_GROUP_ID set. We can
drop this in favor of the fact that ACTION_TASK_GROUP_ID is set to
taskGroupId by
https://hg.mozilla.org/mozilla-central/rev/d4643b526038#l1.14