### PR TITLE
shipit_static_analysis: Replace bugged revision ID parameter with an internal API call.

### DIFF
--- a/src/releng_docs/projects/shipit-static-analysis.rst
+++ b/src/releng_docs/projects/shipit-static-analysis.rst
@@ -138,31 +138,28 @@ So the command would be:
 
 
 
-The bot needs an environment variable ``PHABRICATOR`` with the following information:
-
-1. The phabricator Differential ID (named ``DIFF_ID`` here)
-2. The phabricator Diff PHID (named ``PHID`` here)
+The bot needs an environment variable ``PHABRICATOR`` containing the PHID of the diff to be reviewed.
 
 So you'll need to do the following in the nix shell:
 
 .. code-block:: shell
   
-  export PHABRICATOR="<DIFF_ID>:<PHID>"
+  export PHABRICATOR="<DIFF_PHID>"
 
 Here is an example with this `Phabricator Diff review <https://phabricator-dev.allizom.org/D41>`_:
 
-1. You can get ``DIFF_ID`` from the url (this is ``41``)
+1. You can get the diff ID from the url (this is ``41``)
 2. Login on the Phabricator instance (needed for API queries)
 3. Go to the Conduit API web interface (``/conduit`` of the Phabricator instance), and click on the endpoint ``differential.query`` (direct link to `Phabricator DEV <https://phabricator-dev.allizom.org/conduit/method/differential.query/>`_)
-4. Fill the form field ``ids`` as a JSON list of integer using ``DIFF_ID``, so for our example : ``[41]``
+4. Fill the form field ``ids`` as a JSON list of integer using the diff ID, so for our example : ``[41]``
 5. Click ``Call Method``
-6. The method result should have a ``activeDiffPHID`` key, that's our ``PHID`` (in our example: ``PHID-DIFF-b5wsvctabxjmwqonwryv``)
+6. The method result should have a ``activeDiffPHID`` key, that's our ``DIFF_PHID`` (in our example: ``PHID-DIFF-b5wsvctabxjmwqonwryv``)
 
 Here is the final command line:
 
 .. code-block:: shell
   
-  export PHABRICATOR="41:PHID-DIFF-b5wsvctabxjmwqonwryv"
+  export PHABRICATOR="PHID-DIFF-b5wsvctabxjmwqonwryv"
 
 
 6. Run the bot

--- a/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/listener.py
@@ -95,7 +95,7 @@ class HookPhabricator(Hook):
 
                 # Create new task
                 await self.create_task({
-                    'PHABRICATOR': '{id}:{phid}'.format(**diff)
+                    'PHABRICATOR': diff['phid']
                 })
 
             # Sleep a bit before trying new diffs

--- a/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
@@ -62,7 +62,7 @@ class PhabricatorReporter(Reporter):
 
     def load_diff(self, phid):
         '''
-        Find a differential diff details
+        Find details of a differential diff
         '''
         out = self.request(
             'differential.diff.search',
@@ -73,7 +73,7 @@ class PhabricatorReporter(Reporter):
 
         data = out['data']
         assert len(data) == 1, \
-            'Not found'
+            'Diff not found'
         return data[0]
 
     def load_raw_diff(self, diff_id):
@@ -84,6 +84,22 @@ class PhabricatorReporter(Reporter):
             'differential.getrawdiff',
             diffID=diff_id,
         )
+
+    def load_revision(self, phid):
+        '''
+        Find details of a differential revision
+        '''
+        out = self.request(
+            'differential.revision.search',
+            constraints={
+                'phids': [phid, ],
+            },
+        )
+
+        data = out['data']
+        assert len(data) == 1, \
+            'Revision not found'
+        return data[0]
 
     def publish(self, issues, revision):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -88,7 +88,7 @@ class PhabricatorRevision(Revision):
     '''
     A phabricator revision to process
     '''
-    regex = re.compile(r'^(\d+):(PHID-DIFF-(?:\w+))$')
+    regex = re.compile(r'^(PHID-DIFF-(?:\w+))$')
 
     def __init__(self, description, api):
         self.api = api
@@ -98,13 +98,14 @@ class PhabricatorRevision(Revision):
         if match is None:
             raise Exception('Invalid Phabricator description')
         groups = match.groups()
-        self.id = int(groups[0])
-        self.diff_phid = groups[1]
+        self.diff_phid = groups[0]
 
         # Load diff details to get the diff revision
         diff = self.api.load_diff(self.diff_phid)
         self.diff_id = diff['id']
         self.phid = diff['fields']['revisionPHID']
+        revision = self.api.load_revision(self.phid)
+        self.id = revision.id
 
     def __str__(self):
         return 'Phabricator #{} - {}'.format(self.diff_id, self.diff_phid)

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -105,7 +105,7 @@ class PhabricatorRevision(Revision):
         self.diff_id = diff['id']
         self.phid = diff['fields']['revisionPHID']
         revision = self.api.load_revision(self.phid)
-        self.id = revision.id
+        self.id = revision['id']
 
     def __str__(self):
         return 'Phabricator #{} - {}'.format(self.diff_id, self.diff_phid)

--- a/src/shipit_static_analysis/tests/test_reporter_mail.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mail.py
@@ -93,7 +93,7 @@ def test_mail(mock_issues, mock_phabricator):
     mrev = MozReviewRevision('abcdef:12345:1')
     r.publish(mock_issues, mrev)
 
-    prev = PhabricatorRevision('42:PHID-DIFF-test', phab)
+    prev = PhabricatorRevision('PHID-DIFF-test', phab)
     r.publish(mock_issues, prev)
 
     # Check stats

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -35,7 +35,7 @@ def test_phabricator(mock_phabricator, mock_repository, mock_config):
         'api_key': 'deadbeef',
     })
 
-    r = PhabricatorRevision('51:PHID-DIFF-testABcd12', api)
+    r = PhabricatorRevision('PHID-DIFF-testABcd12', api)
     assert not hasattr(r, 'mercurial')
     assert r.diff_id == 42
     assert r.diff_phid == 'PHID-DIFF-testABcd12'


### PR DESCRIPTION
`shipit_static_analysis` is expecting `<REVISION_ID>:<DIFF_PHID>`, while `shipit_pulse_listener` was sending `<DIFF_ID>:<DIFF_PHID>`, which was causing problems (see #1166).

And actually, you can get `<REVISION_ID>` from `<DIFF_PHID>`, so you can just pass `<DIFF_PHID>` to `shipit_static_analysis` and have it get `<REVISION_ID>` by itself with an API call.