### PR TITLE
shipit-static-analysis: Load full mercurial patch to detect files changes, fixes #1192

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -186,14 +186,19 @@ class MozReviewRevision(Revision):
             force=True,
         )
 
-        # Load changes from specific revision
-        self.patch = repo.diff(change=self.mercurial, git=True).decode('utf-8')
+        # Find ancestor revision
+        out = repo.log('ancestor(tip, {})'.format(self.mercurial))
+        assert out is not None and len(out) > 0, \
+            'Failed to find ancestor for {}'.format(self.mercurial)
+        ancestor = out[0].node.decode('utf-8')
+        logger.info('Found HG ancestor', current=self.mercurial, ancestor=ancestor)
+
+        # Load full diff from revision up to ancestor
+        # using Git format for compatibility with improvement patch builder
+        self.patch = repo.diff(revs=[ancestor, self.mercurial], git=True).decode('utf-8')
 
         # Move repo to ancestor so we don't trigger an unecessary clobber
-        repo.update(
-            rev='ancestor(tip, {})'.format(self.mercurial),
-            clean=True,
-        )
+        repo.update(rev=ancestor, clean=True)
 
     def apply(self, repo):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -186,7 +186,7 @@ class MozReviewRevision(Revision):
             force=True,
         )
 
-        # Find ancestor revision
+        # Find common ancestor revision
         out = repo.log('ancestor(tip, {})'.format(self.mercurial))
         assert out is not None and len(out) > 0, \
             'Failed to find ancestor for {}'.format(self.mercurial)

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import time
 from distutils.spawn import find_executable
+from unittest.mock import Mock
 
 import hglib
 import httpretty
@@ -73,6 +74,9 @@ def mock_repository(mock_config):
     third_party = os.path.join(mock_config.repo_dir, mock_config.third_party)
     with open(third_party, 'w') as f:
         f.write('test/dummy')
+
+    # Remove pull capabilities
+    client.pull = Mock(return_value=True)
 
     return client
 

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -96,7 +96,6 @@ def test_mercurial_patch(mock_config, mock_repository):
     Test mercurial patch creation
     '''
     from shipit_static_analysis.revisions import MozReviewRevision
-    print(mock_config.repo_dir)
 
     def _commit(name):
         path = os.path.join(mock_config.repo_dir, 'review_{}.txt'.format(name))

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -89,3 +89,47 @@ def test_clang_files(mock_revision):
 
     mock_revision.files = ['test.h', 'test.js', 'xxx.txt']
     assert mock_revision.has_clang_files
+
+
+def test_mercurial_patch(mock_config, mock_repository):
+    '''
+    Test mercurial patch creation
+    '''
+    from shipit_static_analysis.revisions import MozReviewRevision
+    print(mock_config.repo_dir)
+
+    def _commit(name):
+        path = os.path.join(mock_config.repo_dir, 'review_{}.txt'.format(name))
+        with open(path, 'w') as f:
+            f.write('Review commit {}'.format(name))
+        mock_repository.add(path.encode('utf-8'))
+        msg = 'Content commit {}'.format(name).encode('utf-8')
+        _, node = mock_repository.commit(msg, user=b'Tester')
+        return node
+
+    # Add an initial commit to exclude
+    assert mock_repository.branch() == b'default'
+    _commit('base')
+
+    # Create a branch
+    mock_repository.branch(b'test-review')
+
+    # Add some commits on test-review
+    commits = [_commit(i) for i in range(5)]
+    revision = commits[-1]
+
+    # Revert to default
+    mock_repository.update(b'default', clean=True)
+
+    # Add a new tip
+    tip = _commit('exclude')
+    assert mock_repository.tip().node == tip
+
+    # Load the revision
+    mozrev = MozReviewRevision('{}:12345:1'.format(revision.decode('utf-8')))
+    mozrev.load(mock_repository)
+    mozrev.analyze_patch()
+
+    # Check the review has all 5 files impacted by branch
+    # but does not have the exclude or base, or anything previous
+    assert mozrev.files == {'review_0.txt', 'review_1.txt', 'review_2.txt', 'review_3.txt', 'review_4.txt'}


### PR DESCRIPTION
I also added a unit test that reproduce a common situation in static analysis: when a patch across multiple revisions is analyzed (through mercurial), the bot should list modified files across the full diff, and not the last revision only.
So i created a branch in a dummy repo with some commits to reproduce this. Only the commits from the branch are detected