### PR TITLE
bug 1459705 - revert 732a570e5726c3ab60c2f562306f91604e1d2364

### DIFF
--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -117,4 +117,6 @@ def generate_action_task(action_name, action_task_input, actions):
 
 def render_action_task(task, context, action_task_id):
     action_task = jsone.render(task, context)
+    # override ACTION_TASK_GROUP_ID, so we know the new ID in advance
+    action_task['payload']['env']['ACTION_TASK_GROUP_ID'] = action_task_id
     return action_task


### PR DESCRIPTION
CoT v3 now allows for the action task group id to be either the
decision or action taskId. Let's go back to the original behavior.