### PR TITLE
shipit-static-analysis: Remove "enabled checks" string detection in clang tidy, refs #1166

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -120,16 +120,14 @@ class ClangTidy(object):
         Parse clang-tidy output into structured issues
         '''
 
-        # Limit clang output parsing to 'Enabled checks:'
-        end = re.search(r'^Enabled checks:\n', clang_output, re.MULTILINE)
-        if end is not None:
-            clang_output = clang_output[:end.start()-1]
-
         # Sort headers by positions
         headers = sorted(
             REGEX_HEADER.finditer(clang_output),
             key=lambda h: h.start()
         )
+        if not headers:
+            logger.warn('No clang-tidy header was found even though a clang output was provided')
+            return []
 
         issues = []
         for i, header in enumerate(headers):

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -18,6 +18,7 @@ from shipit_static_analysis.revisions import Revision
 logger = get_logger(__name__)
 
 REGEX_HEADER = re.compile(r'^(.+):(\d+):(\d+): (warning|error|note): ([^\[\]\n]+)(?: \[([\.\w-]+)\])?$', re.MULTILINE)
+REGEX_HAS_WARNINGS = re.compile(r'^(\d+) warnings present.$', re.MULTILINE)
 
 ISSUE_MARKDOWN = '''
 ## clang-tidy {type}
@@ -119,6 +120,17 @@ class ClangTidy(object):
         '''
         Parse clang-tidy output into structured issues
         '''
+        # Detect end of file warnings count
+        # When an invalid file is used, this line does not appear
+        has_warnings = REGEX_HAS_WARNINGS.search(clang_output)
+        if has_warnings is None:
+            logger.info('Empty clang output, skipping analysis.')
+            return []
+        nb_warnings = int(has_warnings.group(1))
+        if nb_warnings == 0:
+            logger.info('Mach static analysis did not find any issue')
+            return []
+        logger.info('Mach static analysis found some issues', nb=nb_warnings)
 
         # Sort headers by positions
         headers = sorted(
@@ -126,8 +138,7 @@ class ClangTidy(object):
             key=lambda h: h.start()
         )
         if not headers:
-            logger.warn('No clang-tidy header was found even though a clang output was provided')
-            return []
+            raise Exception('No clang-tidy header was found even though a clang output was provided')
 
         issues = []
         for i, header in enumerate(headers):

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -372,7 +372,8 @@ def mock_clang(tmpdir, monkeypatch):
     def mock_mach(command, *args, **kwargs):
         if command[:5] == ['gecko-env', './mach', '--log-no-times', 'static-analysis', 'check']:
             command = ['clang-tidy', ] + command[5:]
-            return real_check_output(command, *args, **kwargs)
+            output = real_check_output(command, *args, **kwargs)
+            return output + b'\n42 warnings present.'
 
         # Really run command through normal check_output
         return real_check_output(command, *args, **kwargs)


### PR DESCRIPTION
The string "Enabled checks:" can move in the mach static-analysis command output, so we cannot rely anymore on it, otherwise we miss some issues.