### PR TITLE
shipit-static-analysis: Phabricator Fixes, refs #1166

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/__init__.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/__init__.py
@@ -127,6 +127,14 @@ class Issue(abc.ABC):
         '''
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def as_dict(self):
+        '''
+        Build the serializable dict representation of the issue
+        Used by debugging tools
+        '''
+        raise NotImplementedError
+
     def is_third_party(self):
         '''
         Is this issue in a third party path ?

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/format.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/format.py
@@ -240,3 +240,24 @@ class ClangFormatIssue(Issue):
             raise Exception('Invalid mode')
 
         return '\n'.join(patch) + '\n'
+
+    def as_dict(self):
+        '''
+        Outputs all available information into a serializable dict
+        '''
+        return {
+            'analyzer': 'clang-format',
+            'mode': self.mode,
+            'path': self.path,
+            'line': self.line,
+            'nb_lines': self.nb_lines,
+            'old_lines': self.old,
+            'new_lines': self.new,
+            'diff': self.as_diff(),
+            'validation': {
+            },
+            'in_patch': self.revision.contains(self),
+            'is_new': self.is_new,
+            'validates': self.validates(),
+            'publishable': self.is_publishable(),
+        }

--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -304,3 +304,29 @@ class ClangTidyIssue(Issue):
         '''
         No diff available
         '''
+
+    def as_dict(self):
+        '''
+        Outputs all available information into a serializable dict
+        '''
+        return {
+            'analyzer': 'clang-tidy',
+            'path': self.path,
+            'line': self.line,
+            'nb_lines': self.nb_lines,
+            'char': self.char,
+            'check': self.check,
+            'type': self.type,
+            'message': self.message,
+            'body': self.body,
+            'notes': [note.as_dict() for note in self.notes],
+            'validation': {
+                'publishable_check': self.has_publishable_check(),
+                'third_party': self.is_third_party(),
+                'is_expanded_macro': self.is_expanded_macro(),
+            },
+            'in_patch': self.revision.contains(self),
+            'is_new': self.is_new,
+            'validates': self.validates(),
+            'publishable': self.is_publishable(),
+        }

--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -118,6 +118,30 @@ class MozLintIssue(Issue):
         No diff available
         '''
 
+    def as_dict(self):
+        '''
+        Outputs all available information into a serializable dict
+        '''
+        return {
+            'analyzer': 'mozlint',
+            'level': self.level,
+            'path': self.path,
+            'linter': self.linter,
+            'line': self.line,
+            'column': self.column,
+            'nb_lines': self.nb_lines,
+            'rule': self.rule,
+            'message': self.message,
+            'validation': {
+                'third_party': self.is_third_party(),
+                'disabled_rule': self.is_disabled_rule(),
+            },
+            'in_patch': self.revision.contains(self),
+            'is_new': self.is_new,
+            'validates': self.validates(),
+            'publishable': self.is_publishable(),
+        }
+
 
 class MozLint(object):
     '''

--- a/src/shipit_static_analysis/shipit_static_analysis/report/base.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/base.py
@@ -32,7 +32,7 @@ You can run this analysis locally with:
 
 '''
 BUG_REPORT = '''
-If you see a problem in this automated review, please report it here: http://bit.ly/2y9N9Vx
+If you see a problem in this automated review, please report it here: {bug_report_url}
 '''
 COMMENT_DIFF_DOWNLOAD = '''
 
@@ -98,7 +98,7 @@ class Reporter(object):
             for cls, items in groups
         ])
 
-    def build_comment(self, issues, diff_url=None, max_comments=None):
+    def build_comment(self, issues, bug_report_url, diff_url=None, max_comments=None):
         '''
         Build a human readable comment about published issues
         '''
@@ -134,7 +134,7 @@ class Reporter(object):
             defects='\n'.join(defects),
             analyzers='\n'.join(analyzers),
         )
-        comment += BUG_REPORT
+        comment += BUG_REPORT.format(bug_report_url=bug_report_url)
         if ClangFormatIssue in stats and diff_url is not None:
             comment += COMMENT_DIFF_DOWNLOAD.format(
                 url=diff_url,

--- a/src/shipit_static_analysis/shipit_static_analysis/report/debug.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/debug.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os.path
+import time
+
+from cli_common import log
+from shipit_static_analysis.report.base import Reporter
+
+logger = log.get_logger(__name__)
+
+
+class DebugReporter(Reporter):
+    '''
+    Debug the issues found and report through the logs
+    Build a json file with all issues details, stored as a TC artifact
+    '''
+    def __init__(self, output_dir):
+        assert os.path.isdir(output_dir), 'Invalid output dir'
+        self.report_path = os.path.join(
+            output_dir,
+            'report.json',
+        )
+
+    def publish(self, issues, revision):
+        '''
+        Display issues choices
+        '''
+        # Simply output issues details through logging
+        logger.info('Debug revision', rev=str(revision))
+        for issue in issues:
+            logger.info(
+                'Issue {}'.format('publishable' if issue.is_publishable() else 'silent'),
+                issue=str(issue),
+            )
+
+        # Output json report in public directory
+        report = {
+            'time': time.time(),
+            'revision': revision.as_dict(),
+            'issues': [
+                issue.as_dict()
+                for issue in issues
+            ],
+        }
+        with open(self.report_path, 'w') as f:
+            json.dump(report, f)

--- a/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/mozreview.py
@@ -25,6 +25,7 @@ MAX_COMMENTS = 30
 COMMENT_SUCCESS = '''
 C/C++ static analysis didn't find any defects in this patch. Hooray!
 '''
+BUG_REPORT_URL = 'http://bit.ly/2y9N9Vx'
 
 
 class MozReviewReporter(Reporter):
@@ -93,6 +94,7 @@ class MozReviewReporter(Reporter):
             comment = self.build_comment(
                 issues=issues,
                 diff_url=revision.diff_url,
+                bug_report_url=BUG_REPORT_URL,
                 max_comments=MAX_COMMENTS
             )
 

--- a/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
@@ -193,7 +193,7 @@ class PhabricatorReporter(Reporter):
             'diffID': revision.diff_id,
             'filePath': issue.path,
             'lineNumber': issue.line,
-            'lineLength': issue.nb_lines,
+            'lineLength': issue.nb_lines - 1,
             'content': issue.as_text(),
         }
         if comment in existing_comments:

--- a/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/phabricator.py
@@ -15,6 +15,8 @@ from shipit_static_analysis.revisions import PhabricatorRevision
 
 logger = log.get_logger(__name__)
 
+BUG_REPORT_URL = 'https://bit.ly/2tb8Qk3'
+
 
 class ConduitError(Exception):
     '''
@@ -133,6 +135,7 @@ class PhabricatorReporter(Reporter):
                 self.build_comment(
                     issues=issues,
                     diff_url=revision.diff_url,
+                    bug_report_url=BUG_REPORT_URL,
                 ),
             )
             stats.api.increment('report.phabricator.issues', len(inlines))

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -140,6 +140,19 @@ class PhabricatorRevision(Revision):
             nocommit=True,
         )
 
+    def as_dict(self):
+        '''
+        Outputs a serializable representation of this revision
+        '''
+        return {
+            'source': 'phabricator',
+            'diff_phid': self.diff_phid,
+            'phid': self.phid,
+            'id': self.id,
+            'url': self.url,
+            'has_clang_files': self.has_clang_files,
+        }
+
 
 class MozReviewRevision(Revision):
     '''
@@ -214,3 +227,16 @@ class MozReviewRevision(Revision):
             rev=self.mercurial,
             clean=True,
         )
+
+    def as_dict(self):
+        '''
+        Outputs a serializable representation of this revision
+        '''
+        return {
+            'source': 'mozreview',
+            'rev': self.mercurial,
+            'review_request': self.review_request_id,
+            'diffset': self.diffset_revision,
+            'url': self.url,
+            'has_clang_files': self.has_clang_files,
+        }

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -26,6 +26,7 @@ from shipit_static_analysis.config import REPO_CENTRAL
 from shipit_static_analysis.config import Publication
 from shipit_static_analysis.config import settings
 from shipit_static_analysis.lint import MozLint
+from shipit_static_analysis.report.debug import DebugReporter
 from shipit_static_analysis.utils import build_temp_file
 
 logger = get_logger(__name__)
@@ -59,6 +60,9 @@ class Workflow(object):
         self.reporters = reporters
         if not self.reporters:
             logger.warn('No reporters configured, this analysis will not be published')
+
+        # Always add debug reporter and Diff reporter
+        self.reporters['debug'] = DebugReporter(output_dir=self.taskcluster_results_dir)
 
         # Finally, clone the mercurial repository
         self.hg = self.clone()

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -97,6 +97,11 @@ def mock_issues():
         def as_text(self):
             return str(self.nb)
 
+        def as_dict(self):
+            return {
+                'nb': self.nb,
+            }
+
         def is_publishable(self):
             return self.nb % 2 == 0
 
@@ -397,7 +402,7 @@ def mock_workflow(tmpdir, mock_repository, mock_config):
         os.environ['MOZCONFIG'] = str(tmpdir.join('mozconfig').realpath())
 
     return MockWorkflow(
-        reporters=[],
+        reporters={},
         analyzers=['clang-tidy', 'clang-format', 'mozlint'],
     )
 

--- a/src/shipit_static_analysis/tests/test_issues.py
+++ b/src/shipit_static_analysis/tests/test_issues.py
@@ -22,6 +22,9 @@ class DummyIssue(Issue):
     def as_text(self):
         return 'empty'
 
+    def as_dict(self):
+        return {}
+
     def validates(self):
         return False
 

--- a/src/shipit_static_analysis/tests/test_reporter_debug.py
+++ b/src/shipit_static_analysis/tests/test_reporter_debug.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
+import os.path
+
+
+def test_publication(tmpdir, mock_issues):
+    '''
+    Test debug publication and report analysis
+    '''
+    from shipit_static_analysis.report.debug import DebugReporter
+    from shipit_static_analysis.revisions import MozReviewRevision
+
+    report_dir = str(tmpdir.mkdir('public').realpath())
+    report_path = os.path.join(report_dir, 'report.json')
+    assert not os.path.exists(report_path)
+
+    r = DebugReporter(report_dir)
+    mrev = MozReviewRevision('abcdef:12345:1')
+    r.publish(mock_issues, mrev)
+
+    assert os.path.exists(report_path)
+    with open(report_path) as f:
+        report = json.load(f)
+
+    assert 'issues' in report
+    assert report['issues'] == [{'nb': 0}, {'nb': 1}, {'nb': 2}, {'nb': 3}, {'nb': 4}]
+
+    assert 'revision' in report
+    assert report['revision'] == {
+        'source': 'mozreview',
+        'rev': 'abcdef',
+        'review_request': 12345,
+        'diffset': 1,
+        'has_clang_files': False,
+        'url': 'https://reviewboard.mozilla.org/r/12345/'
+    }
+
+    assert 'time' in report
+    assert isinstance(report['time'], float)

--- a/src/shipit_static_analysis/tests/test_reporter_mozreview.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mozreview.py
@@ -126,7 +126,7 @@ def test_comment(mock_mozreview, test_cpp, mock_revision):
     assert clang_tidy_publishable.is_publishable()
     issues = [clang_tidy_publishable, ]
 
-    assert reporter.build_comment(issues) == '''
+    assert reporter.build_comment(issues, 'https://report.example.com') == '''
 Code analysis found 1 defect in this patch:
  - 1 defect found by clang-tidy
 
@@ -134,7 +134,7 @@ You can run this analysis locally with:
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
 
 
-If you see a problem in this automated review, please report it here: http://bit.ly/2y9N9Vx
+If you see a problem in this automated review, please report it here: https://report.example.com
 '''
 
     # Now add a clang-format issue
@@ -143,7 +143,7 @@ If you see a problem in this automated review, please report it here: http://bit
     assert clang_tidy_publishable.is_publishable()
     issues.append(clang_format_publishable)
 
-    assert reporter.build_comment(issues) == '''
+    assert reporter.build_comment(issues, 'https://report.example.com') == '''
 Code analysis found 2 defects in this patch:
  - 1 defect found by clang-format
  - 1 defect found by clang-tidy
@@ -153,7 +153,7 @@ You can run this analysis locally with:
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
 
 
-If you see a problem in this automated review, please report it here: http://bit.ly/2y9N9Vx
+If you see a problem in this automated review, please report it here: https://report.example.com
 '''
 
     # Now add a mozlint issue
@@ -162,7 +162,7 @@ If you see a problem in this automated review, please report it here: http://bit
     assert mozlint_publishable.is_publishable()
     issues.append(mozlint_publishable)
 
-    assert reporter.build_comment(issues) == '''
+    assert reporter.build_comment(issues, 'https://report.example.com') == '''
 Code analysis found 3 defects in this patch:
  - 1 defect found by clang-format
  - 1 defect found by clang-tidy
@@ -174,5 +174,5 @@ You can run this analysis locally with:
  - `./mach lint path/to/file` (JS/Python)
 
 
-If you see a problem in this automated review, please report it here: http://bit.ly/2y9N9Vx
+If you see a problem in this automated review, please report it here: https://report.example.com
 '''


### PR DESCRIPTION
Fixes #1166.

* Decrement `nb_lines` by 1 for Phabricator to remove the offset on display
* Use a different bug report url for Phabricator (still pointing at our Github Issues, only the comment changes)
* Introduces a new **debug reporter**, always activated, that:
  * logs all the issues (publishable & silent)
  * build a full json report, stored in the Taskcluster public artifacts dir (already used for diffs)

The debug reports would be used through the taskcluster index API + a small frontend to be built
