### PR TITLE
Support custom Taskcluster routes

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -177,6 +177,7 @@ in rec {
       , taskArtifacts ? {}
       , taskEnv ? {}
       , taskCapabilities ? { privileged = true; }
+      , taskRoutes ? []
       , scopes ? []
       , cache ? {}
       , maxRunTime ? 3600
@@ -198,6 +199,7 @@ in rec {
             cache = cache;
             capabilities = taskCapabilities;
           };
+          routes = taskRoutes;
           scopes = scopes;
           workerType = workerType;
         });

--- a/src/shipit_pulse_listener/shipit_pulse_listener/hook.py
+++ b/src/shipit_pulse_listener/shipit_pulse_listener/hook.py
@@ -93,8 +93,11 @@ class PulseHook(Hook):
         env = self.parse(body)
         if env is None:
             logger.warn('Skipping message, no task created', hook=self.hook_id)
+        elif isinstance(env, list):
+            for e in env:
+                await self.create_task(extra_env=e)
         else:
-            await self.create_task(extra_env=env)
+            raise Exception('Unsupported env type')
 
         # Ack the message so it is removed from the broker's queue
         await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)

--- a/src/shipit_pulse_listener/tests/test_code_coverage_listener.py
+++ b/src/shipit_pulse_listener/tests/test_code_coverage_listener.py
@@ -146,7 +146,7 @@ def test_success():
 
     assert hook.parse({
         'taskGroupId': 'RS0UwZahQ_qAcdZzEb_Y9g'
-    }) == {'REVISION': 'ec3dd3ee2ae4b3a63529a912816a110e925eb2d0'}
+    }) == [{'REVISION': 'ec3dd3ee2ae4b3a63529a912816a110e925eb2d0'}]
 
 
 @responses.activate
@@ -160,4 +160,4 @@ def test_success_windows():
 
     assert hook.parse({
         'taskGroupId': 'MibGDsa4Q7uFNzDf7EV6nw'
-    }) == {'REVISION': '63519bfd42ee379f597c0357af2e712ec3cd9f50'}
+    }) == [{'REVISION': '63519bfd42ee379f597c0357af2e712ec3cd9f50'}]

--- a/src/shipit_static_analysis/default.nix
+++ b/src/shipit_static_analysis/default.nix
@@ -3,7 +3,7 @@
 
 let
 
-  inherit (releng_pkgs.lib) mkTaskclusterHook mkTaskclusterMergeEnv mkPython fromRequirementsFile filterSource ;
+  inherit (releng_pkgs.lib) mkTaskclusterHook mkTaskclusterMergeEnv mkTaskclusterMergeRoutes mkPython fromRequirementsFile filterSource ;
   inherit (releng_pkgs.pkgs) writeScript gcc cacert gcc-unwrapped glibc glibcLocales xorg patch nodejs-8_x git python27 python35 coreutils shellcheck clang_5 zlib;
   inherit (releng_pkgs.pkgs.lib) fileContents concatStringsSep ;
   inherit (releng_pkgs.tools) pypi2nix mercurial;
@@ -38,6 +38,9 @@ let
 
           # Used by cache
           ("docker-worker:cache:" + cacheKey)
+
+          # Needed to index the task in the TaskCluster index
+          ("index:insert-task:project.releng.services.project." + branch + ".shipit_static_analysis.*")
         ];
         cache = {
           "${cacheKey}" = "/cache";
@@ -49,6 +52,12 @@ let
             "MOZ_AUTOMATION" = "1";
           };
         };
+
+        taskRoutes = [
+          # Latest route
+          ("index.project.releng.services.project." + branch + ".shipit_static_analysis.latest")
+        ];
+
         taskCapabilities = {};
         taskCommand = [
           "/bin/shipit-static-analysis"

--- a/src/shipit_static_analysis/shipit_static_analysis/cli.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/cli.py
@@ -125,6 +125,9 @@ def main(source,
             error=e,
         )
 
+        # Index analysis state
+        w.index(revision, state='error')
+
         # Then raise to mark task as erroneous
         raise
 

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -126,7 +126,7 @@ class PhabricatorRevision(Revision):
 
     @property
     def url(self):
-        return 'https://{}/{}/'.format(self.api.hostname, self.diff_phid)
+        return 'https://{}/D{}'.format(self.api.hostname, self.id)
 
     def load(self, repo):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -107,6 +107,12 @@ class PhabricatorRevision(Revision):
         revision = self.api.load_revision(self.phid)
         self.id = revision['id']
 
+    @property
+    def namespaces(self):
+        return [
+            'phabricator.{}.{}'.format(self.id, self.diff_id)
+        ]
+
     def __str__(self):
         return 'Phabricator #{} - {}'.format(self.diff_id, self.diff_phid)
 
@@ -158,17 +164,10 @@ class MozReviewRevision(Revision):
     '''
     A mozreview revision to process
     '''
-    regex = re.compile(r'^(\w+):(\d+):(\d+)$')
-
-    def __init__(self, description):
-        match = self.regex.match(description)
-        if match is None:
-            raise Exception('Invalid Mozreview description')
-
-        groups = match.groups()
-        self.mercurial = groups[0]
-        self.review_request_id = int(groups[1])
-        self.diffset_revision = int(groups[2])
+    def __init__(self, review_request_id, mercurial, diffset_revision):
+        self.mercurial = mercurial
+        self.review_request_id = int(review_request_id)
+        self.diffset_revision = int(diffset_revision)
 
     def __str__(self):
         return 'MozReview #{} - {}'.format(self.review_request_id, self.diffset_revision)
@@ -176,6 +175,12 @@ class MozReviewRevision(Revision):
     @property
     def url(self):
         return 'https://reviewboard.mozilla.org/r/{}/'.format(self.review_request_id) # noqa
+
+    @property
+    def namespaces(self):
+        return [
+            'mozreview.{}.{}'.format(self.review_request_id, self.diffset_revision)
+        ]
 
     def build_diff_name(self):
         return '{}-{}-{}-clang-format.diff'.format(

--- a/src/shipit_static_analysis/shipit_static_analysis/revisions.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/revisions.py
@@ -110,7 +110,10 @@ class PhabricatorRevision(Revision):
     @property
     def namespaces(self):
         return [
-            'phabricator.{}.{}'.format(self.id, self.diff_id)
+            'phabricator.{}'.format(self.id),
+            'phabricator.diff.{}'.format(self.diff_id),
+            'phabricator.phid.{}'.format(self.phid),
+            'phabricator.diffphid.{}'.format(self.diff_phid),
         ]
 
     def __str__(self):
@@ -179,7 +182,9 @@ class MozReviewRevision(Revision):
     @property
     def namespaces(self):
         return [
-            'mozreview.{}.{}'.format(self.review_request_id, self.diffset_revision)
+            'mozreview.{}'.format(self.review_request_id),
+            'mozreview.{}.{}'.format(self.review_request_id, self.diffset_revision),
+            'mozreview.rev.{}'.format(self.mercurial),
         ]
 
     def build_diff_name(self):

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -115,9 +115,6 @@ class Workflow(object):
         for namespace in revision.namespaces:
             self.index(namespace, revision.as_dict())
 
-        # Start by cloning the mercurial repository
-        self.hg = self.clone()
-
         # Add log to find Taskcluster task in papertrail
         logger.info(
             'New static analysis',
@@ -132,6 +129,9 @@ class Workflow(object):
             text='Task {} #{}'.format(self.taskcluster_task_id, self.taskcluster_run_id),
         )
         stats.api.increment('analysis')
+
+        # Start by cloning the mercurial repository
+        self.hg = self.clone()
 
         with stats.api.timer('runtime.mercurial'):
             # Force cleanup to reset top of MC

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -216,12 +216,13 @@ class Workflow(object):
                 for issue in issues:
                     issue.is_new = issue not in before_patch
 
-        self.index(revision, state='analyzed', issues=len(issues))
         if not issues:
             logger.info('No issues, stopping there.')
+            self.index(revision, state='done', issues=0)
             return
 
         # Report issues publication stats
+        self.index(revision, state='analyzed', issues=len(issues))
         stats.api.increment('analysis.issues.publishable', len([i for i in issues if i.is_publishable()]))
 
         # Build patch to help developer improve their code
@@ -232,7 +233,7 @@ class Workflow(object):
             for reporter in self.reporters.values():
                 reporter.publish(issues, revision)
 
-        self.index(revision, state='done')
+        self.index(revision, state='done', issues=len(issues))
 
     def detect_issues(self, analyzers, revision):
         '''

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -33,7 +33,7 @@ from shipit_static_analysis.utils import build_temp_file
 
 logger = get_logger(__name__)
 
-TASKCLUSTER_NAMESPACE = 'index.project.releng.services.project.{channel}.shipit_static_analysis.{name}'
+TASKCLUSTER_NAMESPACE = 'project.releng.services.project.{channel}.shipit_static_analysis.{name}'
 
 
 class Workflow(object):

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -316,14 +316,14 @@ class Workflow(object):
         assert isinstance(revision, Revision)
 
         if not self.on_taskcluster:
-            logger.info('Skipping taskcluster indexation', rev=str(revision), **kwargs)
+            logger.info('Skipping taskcluster indexing', rev=str(revision), **kwargs)
             return
 
         # Build payload
         payload = revision.as_dict()
         payload.update(kwargs)
 
-        # Always add the indexation
+        # Always add the indexing
         now = datetime.utcnow()
         date_format = '%Y-%m-%dT%H:%M:%S.%fZ'
         payload['indexed'] = now.strftime(date_format)

--- a/src/shipit_static_analysis/shipit_static_analysis/workflow.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/workflow.py
@@ -222,8 +222,10 @@ class Workflow(object):
             return
 
         # Report issues publication stats
-        self.index(revision, state='analyzed', issues=len(issues))
-        stats.api.increment('analysis.issues.publishable', len([i for i in issues if i.is_publishable()]))
+        nb_issues = len(issues)
+        nb_publishable = len([i for i in issues if i.is_publishable()])
+        self.index(revision, state='analyzed', issues=nb_issues, issues_publishable=nb_publishable)
+        stats.api.increment('analysis.issues.publishable', nb_publishable)
 
         # Build patch to help developer improve their code
         self.build_improvement_patch(revision, issues)
@@ -233,7 +235,7 @@ class Workflow(object):
             for reporter in self.reporters.values():
                 reporter.publish(issues, revision)
 
-        self.index(revision, state='done', issues=len(issues))
+        self.index(revision, state='done', issues=nb_issues, issues_publishable=nb_publishable)
 
     def detect_issues(self, analyzers, revision):
         '''

--- a/src/shipit_static_analysis/tests/conftest.py
+++ b/src/shipit_static_analysis/tests/conftest.py
@@ -401,10 +401,13 @@ def mock_workflow(tmpdir, mock_repository, mock_config):
     if 'MOZCONFIG' not in os.environ:
         os.environ['MOZCONFIG'] = str(tmpdir.join('mozconfig').realpath())
 
-    return MockWorkflow(
+    workflow = MockWorkflow(
         reporters={},
         analyzers=['clang-tidy', 'clang-format', 'mozlint'],
+        index_service=None,
     )
+    workflow.hg = workflow.clone()
+    return workflow
 
 
 @pytest.fixture

--- a/src/shipit_static_analysis/tests/test_reporter_debug.py
+++ b/src/shipit_static_analysis/tests/test_reporter_debug.py
@@ -18,7 +18,7 @@ def test_publication(tmpdir, mock_issues):
     assert not os.path.exists(report_path)
 
     r = DebugReporter(report_dir)
-    mrev = MozReviewRevision('abcdef:12345:1')
+    mrev = MozReviewRevision('12345', 'abcdef', '1')
     r.publish(mock_issues, mrev)
 
     assert os.path.exists(report_path)

--- a/src/shipit_static_analysis/tests/test_reporter_mail.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mail.py
@@ -90,7 +90,7 @@ def test_mail(mock_issues, mock_phabricator):
     r = MailReporter(conf, 'test_tc', 'token_tc')
 
     # Publish for mozreview
-    mrev = MozReviewRevision('abcdef:12345:1')
+    mrev = MozReviewRevision('12345', 'abcdef', '1')
     r.publish(mock_issues, mrev)
 
     prev = PhabricatorRevision('PHID-DIFF-test', phab)

--- a/src/shipit_static_analysis/tests/test_reporter_mozreview.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mozreview.py
@@ -40,7 +40,7 @@ def test_review_publication(mock_mozreview, mock_issues, mock_phabricator):
         'url': 'http://mozreview.test',
     }
     r = MozReviewReporter(conf, 'test_tc', 'token_tc')
-    mrev = MozReviewRevision('abcdef:12345:1')
+    mrev = MozReviewRevision('12345', 'abcdef', '1')
     out = r.publish(mock_issues, mrev)
     assert out is None  # no publication (no clang-tidy)
 

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -14,7 +14,7 @@ def test_mozreview():
     '''
     from shipit_static_analysis.revisions import MozReviewRevision
 
-    r = MozReviewRevision('308c22e7899048467002de4ffb126cac0875c994:164530:7')
+    r = MozReviewRevision('164530', '308c22e7899048467002de4ffb126cac0875c994', '7')
     assert r.mercurial == '308c22e7899048467002de4ffb126cac0875c994'
     assert r.review_request_id == 164530
     assert r.diffset_revision == 7
@@ -126,7 +126,7 @@ def test_mercurial_patch(mock_config, mock_repository):
     assert mock_repository.tip().node == tip
 
     # Load the revision
-    mozrev = MozReviewRevision('{}:12345:1'.format(revision.decode('utf-8')))
+    mozrev = MozReviewRevision('12345', revision.decode('utf-8'), '1')
     mozrev.load(mock_repository)
     mozrev.analyze_patch()
 

--- a/src/shipit_static_analysis/tests/test_revisions.py
+++ b/src/shipit_static_analysis/tests/test_revisions.py
@@ -39,7 +39,7 @@ def test_phabricator(mock_phabricator, mock_repository, mock_config):
     assert not hasattr(r, 'mercurial')
     assert r.diff_id == 42
     assert r.diff_phid == 'PHID-DIFF-testABcd12'
-    assert r.url == 'https://phabricator.test/PHID-DIFF-testABcd12/'
+    assert r.url == 'https://phabricator.test/D51'
     assert r.build_diff_name() == 'PHID-DIFF-testABcd12-clang-format.diff'
     assert r.id == 51  # revision
 

--- a/src/shipit_static_analysis/tests/test_workflow.py
+++ b/src/shipit_static_analysis/tests/test_workflow.py
@@ -16,6 +16,6 @@ def test_taskcluster_index(mock_workflow):
     mock_workflow.index('dummy.namespace', data={'test': 'dummy'})
 
     args = mock_workflow.index_service.insertTask.call_args[0]
-    assert args[0] == 'index.project.releng.services.project.test.shipit_static_analysis.dummy.namespace'
+    assert args[0] == 'project.releng.services.project.test.shipit_static_analysis.dummy.namespace'
     assert args[1]['taskId'] == '12345deadbeef'
     assert args[1]['data'] == {'test': 'dummy'}

--- a/src/shipit_static_analysis/tests/test_workflow.py
+++ b/src/shipit_static_analysis/tests/test_workflow.py
@@ -6,17 +6,21 @@
 from unittest import mock
 
 
-def test_taskcluster_index(mock_workflow):
+def test_taskcluster_index(mock_workflow, mock_revision):
     '''
     Test the Taskcluster indexation API
     '''
     mock_workflow.index_service = mock.Mock()
     mock_workflow.on_taskcluster = True
     mock_workflow.taskcluster_task_id = '12345deadbeef'
-    mock_workflow.index('dummy.namespace', data={'test': 'dummy'})
+    mock_revision.namespaces = ['mock.1234']
+    mock_revision.as_dict = lambda: {'id': '1234', 'source': 'mock'}
+    mock_workflow.index(mock_revision, test='dummy')
 
     args = mock_workflow.index_service.insertTask.call_args[0]
-    assert args[0] == 'project.releng.services.project.test.shipit_static_analysis.dummy.namespace'
+    assert args[0] == 'project.releng.services.project.test.shipit_static_analysis.mock.1234'
     assert args[1]['taskId'] == '12345deadbeef'
     assert args[1]['data']['test'] == 'dummy'
+    assert args[1]['data']['id'] == '1234'
+    assert args[1]['data']['source'] == 'mock'
     assert 'indexed' in args[1]['data']

--- a/src/shipit_static_analysis/tests/test_workflow.py
+++ b/src/shipit_static_analysis/tests/test_workflow.py
@@ -18,4 +18,5 @@ def test_taskcluster_index(mock_workflow):
     args = mock_workflow.index_service.insertTask.call_args[0]
     assert args[0] == 'project.releng.services.project.test.shipit_static_analysis.dummy.namespace'
     assert args[1]['taskId'] == '12345deadbeef'
-    assert args[1]['data'] == {'test': 'dummy'}
+    assert args[1]['data']['test'] == 'dummy'
+    assert 'indexed' in args[1]['data']

--- a/src/shipit_static_analysis/tests/test_workflow.py
+++ b/src/shipit_static_analysis/tests/test_workflow.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 def test_taskcluster_index(mock_workflow, mock_revision):
     '''
-    Test the Taskcluster indexation API
+    Test the Taskcluster indexing API
     '''
     mock_workflow.index_service = mock.Mock()
     mock_workflow.on_taskcluster = True

--- a/src/shipit_static_analysis/tests/test_workflow.py
+++ b/src/shipit_static_analysis/tests/test_workflow.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittest import mock
+
+
+def test_taskcluster_index(mock_workflow):
+    '''
+    Test the Taskcluster indexation API
+    '''
+    mock_workflow.index_service = mock.Mock()
+    mock_workflow.on_taskcluster = True
+    mock_workflow.taskcluster_task_id = '12345deadbeef'
+    mock_workflow.index('dummy.namespace', data={'test': 'dummy'})
+
+    args = mock_workflow.index_service.insertTask.call_args[0]
+    assert args[0] == 'index.project.releng.services.project.test.shipit_static_analysis.dummy.namespace'
+    assert args[1]['taskId'] == '12345deadbeef'
+    assert args[1]['data'] == {'test': 'dummy'}


### PR DESCRIPTION
The idea here is to index Taskcluster tasks triggered by pulse listener, as soon as they are created, and using extra data from `triggerHook` payload.

Static analysis would use this feature to index tasks with their analysis ID (mozreview ID or phabricator DIFF ID)