### PR TITLE
shipit_static_analysis: Only .capitalize() the first letter of a defect message, not the full message.

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/clang/tidy.py
@@ -264,9 +264,12 @@ class ClangTidyIssue(Issue):
         '''
         Build the text body published on reporters
         '''
+        message = self.message
+        if len(message) > 0:
+            message = message[0].capitalize() + message[1:]
         body = '{}: {} [clang-tidy: {}]'.format(
             self.type.capitalize(),
-            self.message.capitalize(),
+            message,
             self.check,
         )
 

--- a/src/shipit_static_analysis/shipit_static_analysis/lint.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/lint.py
@@ -90,10 +90,13 @@ class MozLintIssue(Issue):
         '''
         Build the text content for reporters
         '''
+        message = self.message
+        if len(message) > 0:
+            message = message[0].capitalize() + message[1:]
         linter = '{}: {}'.format(self.linter, self.rule) if self.rule else self.linter
         return '{}: {} [{}]'.format(
             self.level.capitalize(),
-            self.message.capitalize(),
+            message,
             linter,
         )
 

--- a/src/shipit_static_analysis/tests/test_clang.py
+++ b/src/shipit_static_analysis/tests/test_clang.py
@@ -210,6 +210,18 @@ def test_clang_tidy_parser(mock_config, mock_repository, mock_revision):
     assert issues[0].check == 'mozilla-dangling-on-temporary'
 
 
+def test_as_text(mock_revision):
+    '''
+    Test text export for ClangTidyIssue
+    '''
+    from shipit_static_analysis.clang.tidy import ClangTidyIssue
+    parts = ('test.cpp', '42', '51', 'error', 'dummy message withUppercaseChars', 'dummy-check')
+    issue = ClangTidyIssue(parts, mock_revision)
+    issue.body = 'Dummy body withUppercaseChars'
+
+    assert issue.as_text() == 'Error: Dummy message withUppercaseChars [clang-tidy: dummy-check]'
+
+
 def test_as_markdown(mock_revision):
     '''
     Test markdown generation for ClangTidyIssue

--- a/src/shipit_static_analysis/tests/test_lint.py
+++ b/src/shipit_static_analysis/tests/test_lint.py
@@ -52,3 +52,13 @@ def test_issue_path(mock_repository, mock_config, mock_revision):
     absolute_path = os.path.join(mock_config.repo_dir, relative_path)
     issue = MozLintIssue(absolute_path, 1, 'error', 1, 'dummy', 'Any error', 'XXX', mock_revision)
     assert issue.path == 'test.txt'
+
+
+def test_as_text(mock_revision):
+    '''
+    Test text export for ClangTidyIssue
+    '''
+    from shipit_static_analysis.lint import MozLintIssue
+    issue = MozLintIssue('test.py', 1, 'error', 1, 'flake8', 'dummy test withUppercaseChars', 'dummy rule', mock_revision)
+
+    assert issue.as_text() == 'Error: Dummy test withUppercaseChars [flake8: dummy rule]'


### PR DESCRIPTION
Currently, we export review messages with `.capitalize()`. This causes them to be transformed from:

> Please use ChromeUtils.defineModuleGetter instead of XPCOMUtils.defineLazyModuleGetter

into:

> Please use chromeutils.definemodulegetter instead of xpcomutils.definelazymodulegetter

which is obviously not ideal.

This change should fix #997 on MozReview and Phabricator, for both `clang-tidy` and `mozlint` issues.

@La0 please take a look.